### PR TITLE
 Change Workflow arg start_time_{expression => ''}_factory

### DIFF
--- a/bigflow/dagbuilder.py
+++ b/bigflow/dagbuilder.py
@@ -18,7 +18,7 @@ def generate_dag_file(workdir: str,
                       start_from: typing.Union[datetime, str],
                       build_ver: str,
                       root_package_name: str) -> str:
-    start_from = _coerce_str_to_datetime(start_from)
+    start_from = _str_to_datetime(start_from)
 
     print(f'start_from: {start_from}')
     print(f'build_ver: {build_ver}')
@@ -102,7 +102,7 @@ def get_dag_deployment_id(workflow_name: str,
     return '{workflow_name}__v{ver}__{start_from}'.format(
         workflow_name=workflow_name,
         ver=build_ver.replace('.','_').replace('-','_'),
-        start_from=_coerce_str_to_datetime(start_from).strftime('%Y_%m_%d_%H_%M_%S')
+        start_from=_str_to_datetime(start_from).strftime('%Y_%m_%d_%H_%M_%S')
     )
 
 
@@ -115,7 +115,7 @@ def get_dags_output_dir(workdir: str) -> Path:
     return dags_dir_path
 
 
-def _coerce_str_to_datetime(dt: typing.Union[str, datetime]):
+def _str_to_datetime(dt: typing.Union[str, datetime]):
     if isinstance(dt, datetime):
         return dt
     elif len(dt) <= 10:

--- a/docs/examples/workflow_and_job/hourly_workflow.py
+++ b/docs/examples/workflow_and_job/hourly_workflow.py
@@ -16,7 +16,7 @@ class HourlyJob:
 hourly_workflow = Workflow(
     workflow_id='hourly_workflow',
     schedule_interval='@hourly',
-    start_time_expression_factory=hourly_start_time,
+    start_time_factory=hourly_start_time,
     definition=[HourlyJob()])
 
 if __name__ == '__main__':

--- a/docs/project_setup_and_build.md
+++ b/docs/project_setup_and_build.md
@@ -214,18 +214,17 @@ To see how it works, go to the [`docs`](../docs) project and run the `bigflow bu
 One of the generated DAGs, for the [`resources.py`](examples/project_structure_and_build/resources_workflow.py) workflow, looks like this:
 
 ```python
+import datetime
 from airflow import DAG
-from datetime import timedelta
-from datetime import datetime
 from airflow.contrib.operators import kubernetes_pod_operator
 
 default_args = {
             'owner': 'airflow',
             'depends_on_past': True,
-            'start_date': datetime.strptime("2020-08-31", "%Y-%m-%d") - (timedelta(hours=24)),
+            'start_date': datetime.datetime(2020, 8, 30),
             'email_on_failure': False,
             'email_on_retry': False,
-            'execution_timeout': timedelta(minutes=90)
+            'execution_timeout': datetime.timedelta(minutes=90),
 }
 
 dag = DAG(
@@ -245,7 +244,7 @@ print_resource_job = kubernetes_pod_operator.KubernetesPodOperator(
     image='eu.gcr.io/docker_repository_project/my-project:0.1.0',
     is_delete_operator_pod=True,
     retries=3,
-    retry_delay= timedelta(seconds=60),
+    retry_delay=timedelta(seconds=60),
     dag=dag)
 ```
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,8 +1,10 @@
 import os
 import json
 import shutil
-from pathlib import Path
+import datetime
 import subprocess
+
+from pathlib import Path
 from unittest import TestCase, mock
 
 from bigflow.cli import walk_module_files, SETUP_VALIDATION_MESSAGE
@@ -191,13 +193,13 @@ class BuildDagsCommandE2E(SetupTestCase):
         # then
         self.assertTrue(dags_built(TEST_PROJECT_PATH, 2))
         self.assertFalse(dags_leftovers_exist(TEST_PROJECT_PATH))
-        self.assertTrue(dags_contain(TEST_PROJECT_PATH, now(template="%Y-%m-%d")))
+        self.assertTrue(dags_contain(TEST_PROJECT_PATH, repr(datetime.datetime.now().replace(second=0, minute=0, microsecond=0))))
 
         # when
         self.test_project.run_build("python project_setup.py build_project --build-dags --start-time '2020-01-02 00:00:00'")
 
         # then
-        self.assertTrue(dags_contain(TEST_PROJECT_PATH, '2020-01-02'))
+        self.assertTrue(dags_contain(TEST_PROJECT_PATH, 'datetime.datetime(2020, 1, 2, 0, 0)'))
 
         # when
         self.test_project.run_build('python project_setup.py build_project --build-dags --workflow workflow1')

--- a/test/test_dagbuilder.py
+++ b/test/test_dagbuilder.py
@@ -68,7 +68,7 @@ class DagBuilderTestCase(TestCase):
         workflow = Workflow(
             workflow_id='my_workflow',
             definition=Definition(graph),
-            start_time_expression_factory=hourly_start_time,
+            start_time_factory=hourly_start_time,
             schedule_interval='@hourly')
 
         # when
@@ -78,19 +78,18 @@ class DagBuilderTestCase(TestCase):
         self.assertEqual(dag_file_path, workdir + '/.dags/my_workflow__v0_3_0__2020_07_01_10_00_00_dag.py')
 
         dag_file_content = Path(dag_file_path).read_text()
-        expected_dag_content = '''    
+        expected_dag_content = '''
+import datetime
 from airflow import DAG
-from datetime import timedelta
-from datetime import datetime
 from airflow.contrib.operators import kubernetes_pod_operator
 
 default_args = {
             'owner': 'airflow',
             'depends_on_past': True,
-            'start_date': datetime.strptime("2020-07-01 10:00:00", "%Y-%m-%d %H:%M:%S") - (timedelta(seconds='''+self.expected_start_date_shift()+''')),
+            'start_date': datetime.datetime(2020, 7, 1, 10, 0),
             'email_on_failure': False,
             'email_on_retry': False,
-            'execution_timeout': timedelta(minutes=90)
+            'execution_timeout': datetime.timedelta(minutes=90),
 }
 
 dag = DAG(
@@ -110,7 +109,7 @@ tjob1 = kubernetes_pod_operator.KubernetesPodOperator(
     image='eu.gcr.io/my_docker_repository_project/my-project:0.3.0',
     is_delete_operator_pod=True,
     retries=10,
-    retry_delay= timedelta(seconds=20),
+    retry_delay=datetime.timedelta(seconds=20),
     dag=dag)            
 
 
@@ -123,7 +122,7 @@ tjob2 = kubernetes_pod_operator.KubernetesPodOperator(
     image='eu.gcr.io/my_docker_repository_project/my-project:0.3.0',
     is_delete_operator_pod=True,
     retries=100,
-    retry_delay= timedelta(seconds=200),
+    retry_delay=datetime.timedelta(seconds=200),
     dag=dag)            
 
 tjob2.set_upstream(tjob1)
@@ -137,7 +136,7 @@ tjob3 = kubernetes_pod_operator.KubernetesPodOperator(
     image='eu.gcr.io/my_docker_repository_project/my-project:0.3.0',
     is_delete_operator_pod=True,
     retries=100,
-    retry_delay= timedelta(seconds=200),
+    retry_delay=datetime.timedelta(seconds=200),
     dag=dag)            
 
 tjob3.set_upstream(tjob2)
@@ -174,19 +173,18 @@ tjob3.set_upstream(tjob1)
         self.assertEqual(dag_file_path, workdir + '/.dags/my_daily_workflow__v0_3_0__2020_07_01_00_00_00_dag.py')
 
         dag_file_content = Path(dag_file_path).read_text()
-        expected_dag_content = '''    
+        expected_dag_content = '''
+import datetime
 from airflow import DAG
-from datetime import timedelta
-from datetime import datetime
 from airflow.contrib.operators import kubernetes_pod_operator
 
 default_args = {
             'owner': 'airflow',
             'depends_on_past': True,
-            'start_date': datetime.strptime("2020-07-01", "%Y-%m-%d") - (timedelta(hours=24)),
+            'start_date': datetime.datetime(2020, 7, 1, 0, 0),
             'email_on_failure': False,
             'email_on_retry': False,
-            'execution_timeout': timedelta(minutes=90)
+            'execution_timeout': datetime.timedelta(minutes=90),
 }
 
 dag = DAG(
@@ -206,7 +204,7 @@ tjob1 = kubernetes_pod_operator.KubernetesPodOperator(
     image='eu.gcr.io/my_docker_repository_project/my-project:0.3.0',
     is_delete_operator_pod=True,
     retries=10,
-    retry_delay= timedelta(seconds=20),
+    retry_delay=datetime.timedelta(seconds=20),
     dag=dag)            
 
 '''


### PR DESCRIPTION
Change 'bigflow.Workflow' constructor argument start_time_expression_factory:
 - renamed to `start_time_factory`
 - type of callback changed from str->str to datetime->datetime
 - dagbuilder.* functions accept both 'str' (old variant) and datetime objects
 - generated dags contains 'repr(<`datetime obj>)`
 - documentation is *not* updated (is under work in another PR).