### PR TITLE
Extend Job api

### DIFF
--- a/bigflow/__init__.py
+++ b/bigflow/__init__.py
@@ -1,5 +1,5 @@
 from . import resources
-from .workflow import Workflow, Definition
+from .workflow import Workflow, Definition, Job, JobContext
 from .configuration import Config
 
 from bigflow._version import __version__
@@ -8,6 +8,8 @@ from bigflow._version import __version__
 __all__ = [
     # core
     'Workflow',
+    'Job',
+    'JobContext',
     'Definition',
     'Config',
     'resources',

--- a/bigflow/bigquery/job.py
+++ b/bigflow/bigquery/job.py
@@ -22,7 +22,7 @@ class Job(bigflow.Job):
         self.retry_pause_sec = retry_pause_sec
 
     def execute(self, context: bigflow.JobContext):
-        return self._run_component(self._build_dependencies(context.runtime_as_str))
+        return self._run_component(self._build_dependencies(context.runtime_str))
 
     def _build_dependencies(self, runtime):
         return {

--- a/bigflow/bigquery/job.py
+++ b/bigflow/bigquery/job.py
@@ -1,3 +1,5 @@
+import bigflow
+
 from inspect import getargspec
 from .dataset_manager import create_dataset_manager
 
@@ -5,7 +7,8 @@ DEFAULT_RETRY_COUNT = 3
 DEFAULT_RETRY_PAUSE_SEC = 60
 
 
-class Job(object):
+class Job(bigflow.Job):
+
     def __init__(self,
                  component,
                  id=None,
@@ -18,8 +21,8 @@ class Job(object):
         self.retry_count = retry_count
         self.retry_pause_sec = retry_pause_sec
 
-    def run(self, runtime):
-        return self._run_component(self._build_dependencies(runtime))
+    def execute(self, context: bigflow.JobContext):
+        return self._run_component(self._build_dependencies(context.runtime_as_str))
 
     def _build_dependencies(self, runtime):
         return {
@@ -47,6 +50,7 @@ class Job(object):
         raise ValueError("Can't find config for dependency: " + target_dependency_name)
 
     def _build_dependency(self, dependency_config, runtime):
-        _, dataset_manager = create_dataset_manager(runtime=runtime,
+        _, dataset_manager = create_dataset_manager(
+            runtime=runtime,
             **dependency_config._as_dict())
         return dataset_manager

--- a/bigflow/workflow.py
+++ b/bigflow/workflow.py
@@ -35,7 +35,7 @@ def daily_start_time(start_time: dt.datetime) -> dt.datetime:
 class JobContext(typing.NamedTuple):
 
     runtime: typing.Optional[dt.datetime]
-    runtime_as_str: typing.Optional[str]
+    runtime_str: typing.Optional[str]
     workflow: typing.Optional['Workflow']
     # TODO: add unique 'workflow execution id' (for tracing/logging)
 
@@ -44,22 +44,22 @@ class JobContext(typing.NamedTuple):
         cls,
         *,
         runtime: typing.Union[str, dt.datetime, None] = None,
-        runtime_as_str: typing.Optional[str] = None,
+        runtime_str: typing.Optional[str] = None,
         workflow: typing.Optional['Workflow'] = None,
     ):
         if isinstance(runtime, str):
             warnings.warn("Using `str` as `runtime` value is deprecated, please provide instance of `datetime`", DeprecationWarning)
-            runtime_as_str = runtime_as_str or runtime
+            runtime_str = runtime_str or runtime
             runtime = _parse_runtime_str(runtime)
         elif runtime is None:
             runtime = dt.datetime.now()
 
-        if not runtime_as_str and runtime:
-            runtime_as_str = runtime.strftime(_RUNTIME_FORMATS[0])
+        if not runtime_str and runtime:
+            runtime_str = runtime.strftime(_RUNTIME_FORMATS[0])
 
         return cls(
             runtime=runtime,
-            runtime_as_str=runtime_as_str,
+            runtime_str=runtime_str,
             workflow=workflow,
         )
 
@@ -105,7 +105,7 @@ class Workflow(object):
         else:
             # fallback to old api
             warnings.warn("Old bigflow.Job api is used, please implement method `execute` (see bigflow.Job)")
-            job.run(context.runtime_as_str)
+            job.run(context.runtime_str)
 
     def _make_job_context(self, runtime):
         return JobContext.make(workflow=self, runtime=runtime)

--- a/bigflow/workflow.py
+++ b/bigflow/workflow.py
@@ -40,6 +40,9 @@ class JobContext(typing.NamedTuple):
 class Job(abc.ABC):
     """Base abstract class for bigflow.Jobs.  It is recommended to inherit all your jobs from this class."""
 
+    retries: int = 3
+    retry_delay: float = 60
+
     @property
     @abc.abstractmethod
     def id(self) -> str:

--- a/bigflow/workflow.py
+++ b/bigflow/workflow.py
@@ -31,13 +31,11 @@ def daily_start_time(start_time: dt.datetime) -> dt.datetime:
 
 
 class JobContext(typing.NamedTuple):
-    runtime_raw: typing.Optional[str]
     runtime: typing.Optional[dt.datetime]
-    env: typing.Optional[str]
+    runtime_raw: typing.Optional[str]
     workflow: typing.Optional['Workflow']
     workflow_id: typing.Optional[str]
     # TODO: add unique 'workflow execution id' (for tracing/logging)
-    # TODO: add some 'workflow-level' configuration here
 
 
 class Job(abc.ABC):
@@ -104,7 +102,6 @@ class Workflow(object):
             runtime_raw=runtime_raw,
             workflow_id=self.workflow_id,
             workflow=self,
-            env='',  # TODO: capture the env
         )        
 
     def run(self, runtime: typing.Union[dt.datetime, str, None] = None):

--- a/bigflow/workflow.py
+++ b/bigflow/workflow.py
@@ -51,6 +51,8 @@ class JobContext(typing.NamedTuple):
             warnings.warn("Using `str` as `runtime` value is deprecated, please provide instance of `datetime`", DeprecationWarning)
             runtime_str = runtime_str or runtime
             runtime = _parse_runtime_str(runtime)
+        elif isinstance(runtime, dt.date):
+            runtime = dt.datetime(runtime.year, runtime.month, runtime.day)
         elif runtime is None:
             runtime = dt.datetime.now()
 
@@ -154,7 +156,7 @@ class WorkflowJob:
         return self.job.id
 
     def run(self, runtime):
-        self.job.run(runtime=runtime)
+        self.job.run(runtime)
 
     def execute(self, context: JobContext):
         self.job.execute(context)

--- a/bigflow/workflow.py
+++ b/bigflow/workflow.py
@@ -72,10 +72,10 @@ class Workflow(object):
         self.start_time_factory = start_time_factory
         self.log_config = log_config
 
-    def _parse_runtime_str(self, rt: str):
-        for fmt in self.RUNTIME_FORMATS:
+    def _parse_runtime_str(self, runtime: str):
+        for format in self.RUNTIME_FORMATS:
             try:
-                return dt.datetime.strptime(rt, fmt)
+                return dt.datetime.strptime(runtime, format)
             except ValueError:
                 pass
         raise ValueError("Unable to parse 'run_time' %r" % rt)

--- a/bigflow/workflow.py
+++ b/bigflow/workflow.py
@@ -32,9 +32,8 @@ def daily_start_time(start_time: dt.datetime) -> dt.datetime:
 
 class JobContext(typing.NamedTuple):
     runtime: typing.Optional[dt.datetime]
-    runtime_raw: typing.Optional[str]
+    runtime_as_str: typing.Optional[str]
     workflow: typing.Optional['Workflow']
-    workflow_id: typing.Optional[str]
     # TODO: add unique 'workflow execution id' (for tracing/logging)
 
 
@@ -87,21 +86,20 @@ class Workflow(object):
             job.execute(context)
         else:
             # fallback to old api
-            job.run(context.runtime_raw)
+            job.run(context.runtime_as_str)
 
     def _make_job_context(self, runtime_raw):
         if isinstance(runtime_raw, str):
+            runtime_as_str = runtime_raw
             runtime = self._parse_runtime_str(runtime_raw)
-        elif runtime_raw:
-            runtime = runtime_raw
         else:
-            runtime = dt.datetime.now()
+            runtime = runtime_raw or dt.datetime.now()
+            runtime_as_str = runtime.strftime(self.RUNTIME_FORMATS[0])
 
         return JobContext(
-            runtime=runtime,
-            runtime_raw=runtime_raw,
-            workflow_id=self.workflow_id,
             workflow=self,
+            runtime=runtime,
+            runtime_as_str=runtime_as_str,
         )        
 
     def run(self, runtime: typing.Union[dt.datetime, str, None] = None):

--- a/bigflow/workflow.py
+++ b/bigflow/workflow.py
@@ -81,10 +81,12 @@ class Workflow(object):
 
     def _execute_job(self, job, context):
         if not isinstance(job, Job):
-            logger.warn("Please, inherit your job %r from `bigflow.Job` class", job)
+            logger.debug("Please, inherit your job %r from `bigflow.Job` class", job)
         if hasattr(job, 'execute'):
             job.execute(context)
         else:
+            logger.warn("Old bigflow.Job api is used: please change `run(runtime) => execute(context)`)")
+            raise Exception("XXX")
             # fallback to old api
             job.run(context.runtime_as_str)
 

--- a/docs/examples/cli/hello_config_workflow.py
+++ b/docs/examples/cli/hello_config_workflow.py
@@ -1,26 +1,32 @@
-from bigflow import Config
-from bigflow.workflow import Workflow
+import bigflow
 
 
-config = Config(name='dev',
-                properties={
-                        'message_to_print': 'Message to print on DEV'
-                }).add_configuration(
-                name='prod',
-                properties={
-                       'message_to_print': 'Message to print on PROD'
-                })
+config = bigflow.Config(
+    name='dev',
+    properties={
+        'message_to_print': 'Message to print on DEV'
+    },
+).add_configuration(
+    name='prod',
+    properties={
+        'message_to_print': 'Message to print on PROD'
+    },
+)
 
 
-class HelloConfigJob:
+class HelloConfigJob(bigflow.Job):
+    id = 'hello_config_job'
+
     def __init__(self, message_to_print):
-        self.id = 'hello_config_job'
         self.message_to_print = message_to_print
 
-    def run(self, runtime):
+    def execute(self, context: bigflow.JobContext):
         print(self.message_to_print)
 
 
-hello_world_workflow = Workflow(
+hello_world_workflow = bigflow.Workflow(
     workflow_id='hello_config_workflow',
-    definition=[HelloConfigJob(config.resolve_property('message_to_print'))])
+    definition=[
+        HelloConfigJob(config.resolve_property('message_to_print')),
+    ],
+)

--- a/docs/examples/cli/hello_world_workflow.py
+++ b/docs/examples/cli/hello_world_workflow.py
@@ -1,24 +1,24 @@
-from bigflow.workflow import Workflow
+import bigflow
 
 
-class HelloWorldJob:
-    def __init__(self):
-        self.id = 'hello_world'
+class HelloWorldJob(bigflow.Job):
+    id = 'hello_world'
 
-    def run(self, runtime):
-        print(f'Hello world on {runtime}!')
+    def execute(self, context: bigflow.JobContext):
+        print(f'Hello world on {context.runtime}!')
 
 
-class SayGoodbyeJob:
-    def __init__(self):
-        self.id = 'say_goodbye'
+class SayGoodbyeJob(bigflow.Job):
+    id = 'say_goodbye'
 
-    def run(self, runtime):
+    def run(self, context: bigflow.JobContext):
         print(f'Goodbye!')
 
 
-hello_world_workflow = Workflow(
+hello_world_workflow = bigflow.Workflow(
     workflow_id='hello_world_workflow',
     definition=[
         HelloWorldJob(),
-        SayGoodbyeJob()])
+        SayGoodbyeJob(),
+    ],
+)

--- a/docs/examples/cli/hello_world_workflow.py
+++ b/docs/examples/cli/hello_world_workflow.py
@@ -11,7 +11,7 @@ class HelloWorldJob(bigflow.Job):
 class SayGoodbyeJob(bigflow.Job):
     id = 'say_goodbye'
 
-    def run(self, context: bigflow.JobContext):
+    def execute(self, context: bigflow.JobContext):
         print(f'Goodbye!')
 
 

--- a/docs/examples/project_structure_and_build/resources_workflow.py
+++ b/docs/examples/project_structure_and_build/resources_workflow.py
@@ -1,17 +1,20 @@
 from pathlib import Path
+
+import bigflow
 from bigflow.resources import get_resource_absolute_path
-from bigflow.workflow import Workflow
 
 
-class PrintResourceJob:
-    def __init__(self):
-        self.id = 'print_resource_job'
+class PrintResourceJob(bigflow.Job):
+    id = 'print_resource_job'
 
-    def run(self, runtime):
+    def context(self, context: bigflow.JobContext):
         with open(get_resource_absolute_path('example_resource.txt', Path(__file__))) as f:
             print(f.read())
 
 
-resources_workflow = Workflow(
+resources_workflow = bigflow.Workflow(
     workflow_id='resources_workflow',
-    definition=[PrintResourceJob()])
+    definition=[
+        PrintResourceJob(),
+    ],
+)

--- a/docs/examples/workflow_and_job/daily_workflow.py
+++ b/docs/examples/workflow_and_job/daily_workflow.py
@@ -1,17 +1,20 @@
+import datetime
 import bigflow
-
 
 class DailyJob(bigflow.Job):
     id = 'daily_job'
 
-    def run(self, runtime):
-        print(f'I should process data with timestamps from: {runtime} to {runtime[:10]} 23:59:00')
-
+    def execute(self, context):
+        dt1 = context.runtime
+        dt2 = dt1 + datetime.timedelta(days=1, seconds=-1)
+        print(f'I should process data with timestamps from: {dt1} to {dt2}')
 
 daily_workflow = Workflow(
     workflow_id='daily_workflow',
     schedule_interval='@daily',
-    definition=[DailyJob()])
+    definition=[
+        DailyJob(),
+    ],
+)
 
-if __name__ == '__main__':
-    daily_workflow.run('2020-01-01 00:00:00')
+daily_workflow.run(datetime.datetime(2020, 1, 1))

--- a/docs/examples/workflow_and_job/daily_workflow.py
+++ b/docs/examples/workflow_and_job/daily_workflow.py
@@ -1,9 +1,8 @@
-from bigflow.workflow import Workflow
+import bigflow
 
 
-class DailyJob:
-    def __init__(self):
-        self.id = 'daily_job'
+class DailyJob(bigflow.Job):
+    id = 'daily_job'
 
     def run(self, runtime):
         print(f'I should process data with timestamps from: {runtime} to {runtime[:10]} 23:59:00')

--- a/docs/examples/workflow_and_job/graph_workflow.py
+++ b/docs/examples/workflow_and_job/graph_workflow.py
@@ -4,11 +4,14 @@ from .sequential_workflow import Job
 
 job1, job2, job3, job4 = Job('1'), Job('2'), Job('3'), Job('4')
 
-graph_workflow = Workflow(workflow_id='graph_workflow', definition=Definition({
-    job1: (job2, job3),
-    job2: (job4,),
-    job3: (job4,)
-}))
+graph_workflow = Workflow(
+    workflow_id='graph_workflow', 
+    definition=Definition({
+        job1: [job2, job3],
+        job2: [job4],
+        job3: [job4],
+    }),
+)
 
 if __name__ == '__main__':
     graph_workflow.run()

--- a/docs/examples/workflow_and_job/hourly_workflow.py
+++ b/docs/examples/workflow_and_job/hourly_workflow.py
@@ -1,23 +1,18 @@
-from bigflow.workflow import Workflow, hourly_start_time
+import datetime
+import bigflow
+from bigflow.workflow import hourly_start_time
 
-from datetime import datetime
-from datetime import timedelta
+class HourlyJob(bigflow.Job):
+    id = 'hourly_job'
 
+    def execute(self, context):
+        print(f'I should process data with timestamps from: {context.runtime} '
+              f'to {context.runtime + datetime.timedelta(minutes=59, seconds=59)}')
 
-class HourlyJob:
-    def __init__(self):
-        self.id = 'hourly_job'
-
-    def run(self, runtime):
-        print(f'I should process data with timestamps from: {runtime} '
-              f'to {datetime.strptime(runtime, "%Y-%m-%d %H:%M:%S") + timedelta(minutes=59, seconds=59)}')
-
-
-hourly_workflow = Workflow(
+hourly_workflow = bigflow.Workflow(
     workflow_id='hourly_workflow',
     schedule_interval='@hourly',
     start_time_factory=hourly_start_time,
-    definition=[HourlyJob()])
-
-if __name__ == '__main__':
-    hourly_workflow.run('2020-01-01 00:00:00')
+    definition=[HourlyJob()],
+)
+hourly_workflow.run(datetime.datetime(2020, 1, 1, 10))

--- a/docs/examples/workflow_and_job/retriable_job.py
+++ b/docs/examples/workflow_and_job/retriable_job.py
@@ -1,8 +1,12 @@
-class SimpleRetriableJob:
+import bigflow
+
+class SimpleRetriableJob(bigflow.Job):
+
     def __init__(self, id):
         self.id = id
         self.retry_count = 20
         self.retry_pause_sec = 100
 
-    def run(self, runtime):
-        print(runtime)
+    def execute(self, context: bigflow.JobContext):
+        print("execution runtime as `datetime` object": context.runtime)
+        print("reference to workflow", context.workflow)

--- a/docs/examples/workflow_and_job/sequential_workflow.py
+++ b/docs/examples/workflow_and_job/sequential_workflow.py
@@ -5,13 +5,14 @@ class Job(object):
     def __init__(self, id):
         self.id = id
 
-    def run(self, runtime):
-        print(f'Running job {self.id} at {runtime}')
+    def execute(self, context):
+        print(f'Running job {self.id} at {context.runtime}')
 
 
 example_workflow = Workflow(
     workflow_id='example_workflow',
-    definition=[Job('1'), Job('2')])
+    definition=[Job('1'), Job('2')],
+)
 
 if __name__ == '__main__':
     example_workflow.run()

--- a/docs/examples/workflow_and_job/simple_workflow_and_job.py
+++ b/docs/examples/workflow_and_job/simple_workflow_and_job.py
@@ -5,7 +5,7 @@ class SimpleJob:
     def __init__(self):
         self.id = 'simple_job'
 
-    def run(self, runtime):
+    def execute(self, runtime):
         print(f'Running a simple job')
 
 

--- a/docs/workflow-and-job.md
+++ b/docs/workflow-and-job.md
@@ -14,16 +14,16 @@ The simplest workflow you can create looks like this:
 
 [`simple_workflow_and_job.py`](examples/workflow_and_job/simple_workflow_and_job.py)
 ```python
-from bigflow.workflow import Workflow
+import bigflow
 
 class SimpleJob:
     def __init__(self):
         self.id = 'simple_job'
 
-    def run(self, runtime):
+    def execute(self, context: bigflow.JobContext):
         print(f'Running a simple job')
 
-simple_workflow = Workflow(workflow_id='simple_workflow', definition=[SimpleJob()])
+simple_workflow = bigflow.Workflow(workflow_id='simple_workflow', definition=[SimpleJob()])
 ```
 
 You can run this workflow within a Python module:

--- a/docs/workflow-and-job.md
+++ b/docs/workflow-and-job.md
@@ -16,14 +16,16 @@ The simplest workflow you can create looks like this:
 ```python
 import bigflow
 
-class SimpleJob:
-    def __init__(self):
-        self.id = 'simple_job'
+class SimpleJob(bigflow.Job):
+    id = 'simple job'
 
     def execute(self, context: bigflow.JobContext):
         print(f'Running a simple job')
 
-simple_workflow = bigflow.Workflow(workflow_id='simple_workflow', definition=[SimpleJob()])
+simple_workflow = bigflow.Workflow(
+    workflow_id='simple_workflow',
+    definition=[SimpleJob()],
+)
 ```
 
 You can run this workflow within a Python module:
@@ -45,26 +47,31 @@ Running workflows and jobs from a module is useful for debugging. In any other c
 
 ## Job
 
-A job is just an object with a unique `id` and the `run` method.
+A job is just an object with a unique `id` and the `execute` method.
 
 The `id` parameter is a string that should be a valid Python variable name. For example — `'my_example_job'`, `'MY_EXAMPLE_JOB'`, `'job1234'`.
 
-The Job `run` method a single argument — `runtime`. The `runtime` parameter is a data-time string. 
-You can find more information about `runtime` and scheduling [workflow scheduling options](#workflow-scheduling-options).
+The Job `run` method a single argument — `context`. The `context` parameter is an object of type `bigflow.JobContext`.
+It keeps execution timestamp, reference to workflow. You can find more information about `context`
+and scheduling [workflow scheduling options](#workflow-scheduling-options).
 
 There are 2 additional parameters, that a job can supply to Airflow: `retry_count` and `retry_pause_sec`. The `retry_count` parameter
 determines how many times a job will be retried (in case of a failure). The `retry_pause_sec` parameter says how long the pause between retries should be.
 
 [`retriable_job.py`](examples/workflow_and_job/retriable_job.py)
 ```python
-class SimpleRetriableJob:
+import bigflow
+
+class SimpleRetriableJob(bigflow.Job):
+
     def __init__(self, id):
         self.id = id
         self.retry_count = 20
         self.retry_pause_sec = 100
 
-    def run(self, runtime):
-        print(runtime)
+    def execute(self, context: bigflow.JobContext):
+        print("execution runtime as `datetime` object": context.runtime)
+        print("reference to workflow", context.workflow)
 ```
 
 ## Workflow
@@ -80,16 +87,18 @@ There are two ways of specifying the job arrangement. When your jobs are execute
 ```python
 from bigflow.workflow import Workflow
 
-class Job(object):
+class Job(bigflow.Job):
+
     def __init__(self, id):
         self.id = id
 
-    def run(self, runtime):
-        print(f'Running job {self.id} at {runtime}')
+    def execute(self, context: bigflow.JobContext):
+        print(f'Running job {self.id} at {context.runtime}')
 
 example_workflow = Workflow(
     workflow_id='example_workflow',
-    definition=[Job('1'), Job('2')])
+    definition=[Job('1'), Job('2')],
+)
 
 example_workflow.run()
 ```
@@ -117,11 +126,15 @@ The implementation:
 ```python
 job1, job2, job3, job4 = Job('1'), Job('2'), Job('3'), Job('4')
 
-graph_workflow = Workflow(workflow_id='graph_workflow', definition=Definition({
-    job1: (job2, job3),
-    job2: (job4,),
-    job3: (job4,)
-}))
+graph_workflow = Workflow(
+    workflow_id='graph_workflow', 
+    definition=Definition({
+        job1: [job2, job3],
+        job2: [job4],
+        job3: [job4],
+    }),
+)
+
 graph_workflow.run()
 ```
 
@@ -140,11 +153,13 @@ without providing the `runtime` parameter, the `Workflow` class passes the curre
 ```python
 simple_workflow = Workflow(
     workflow_id='simple_workflow',
-    definition=[Job('1')])
+    definition=[Job('1')],
+)
+
 simple_workflow.run_job('1')
 simple_workflow.run()
-simple_workflow.run_job('1', '1970-01-01 00:00:00')
-simple_workflow.run('1970-01-01 00:00:00')
+simple_workflow.run_job('1', datetime.datetime(year=1970, month=1, day=1))
+simple_workflow.run(datetime.datetime(year=1970, month=1, day=1))
 ```
 
 The `Workflow.run` method ignores job parameters like `retry_count` and `retry_pause_sec`. It executes a workflow in a 
@@ -211,18 +226,23 @@ For example:
 
 [`daily_workflow.py`](examples/workflow_and_job/daily_workflow.py):
 ```python
-class DailyJob:
-    def __init__(self):
-        self.id = 'daily_job'
+class DailyJob(bigflow.Job):
+    id = 'daily_job'
 
-    def run(self, runtime):
-        print(f'I should process data with timestamps from: {runtime} to {runtime[:10]} 23:59:00')
+    def execute(self, context):
+        dt1 = context.runtime
+        dt2 = dt1 + datetime.timedelta(days=1, seconds=-1)
+        print(f'I should process data with timestamps from: {dt1} to {dt2}')
 
 daily_workflow = Workflow(
     workflow_id='daily_workflow',
     schedule_interval='@daily',
-    definition=[DailyJob()])
-daily_workflow.run('2020-01-01 00:00:00')
+    definition=[
+        DailyJob(),
+    ],
+)
+
+daily_workflow.run(datetime.datetime(2020, 1, 1))
 ```
 
 Output:
@@ -238,21 +258,24 @@ For example:
 
 [`hourly_workflow.py`](examples/workflow_and_job/hourly_workflow.py):
 ```python
+import datetime
+import bigflow
 from bigflow.workflow import hourly_start_time
-class HourlyJob:
-    def __init__(self):
-        self.id = 'hourly_job'
 
-    def run(self, runtime):
-        print(f'I should process data with timestamps from: {runtime} '
-              f'to {datetime.strptime(runtime, "%Y-%m-%d %H:%M:%S") + timedelta(minutes=59, seconds=59) }')
+class HourlyJob(bigflow.Job):
+    id = 'hourly_job'
 
-hourly_workflow = Workflow(
+    def execute(self, context):
+        print(f'I should process data with timestamps from: {context.runtime} '
+              f'to {context.runtime + datetime.timedelta(minutes=59, seconds=59)}')
+
+hourly_workflow = bigflow.Workflow(
     workflow_id='hourly_workflow',
     schedule_interval='@hourly',
     start_time_factory=hourly_start_time,
-    definition=[HourlyJob()])
-hourly_workflow.run('2020-01-01 10:00:00')
+    definition=[HourlyJob()],
+)
+hourly_workflow.run(datetime.datetime(2020, 1, 1, 10))
 ```
 
 Output:

--- a/setup.py
+++ b/setup.py
@@ -3,22 +3,13 @@
 import setuptools
 import os
 
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-with open(os.path.join('requirements', 'base.txt'), 'r') as base_requirements:
-    install_requires = [l.strip() for l in base_requirements.readlines()]
-
-with open(os.path.join('requirements', 'monitoring_extras.txt'), 'r') as monitoring_extras_requirements:
-    monitoring_extras_require = [
-        l.strip() for l in monitoring_extras_requirements.readlines()]
-
-with open(os.path.join('requirements', 'bigquery_extras.txt'), 'r') as bigquery_extras_requirements:
-    bigquery_extras_require = [l.strip() for l in bigquery_extras_requirements.readlines()]
-
-with open(os.path.join('requirements', 'log_extras.txt'), 'r') as log_extras_requirements:
-    log_extras_require = [l.strip() for l in log_extras_requirements.readlines()]
-
+def read_requirements(name):
+    with open(os.path.join("requirements", name)) as f:
+        return list(map(str.strip, f))
 
 with open(os.path.join('bigflow', '_version.py'), 'r') as version_file:
     version_globals = {}
@@ -48,11 +39,11 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
-    install_requires=install_requires,
+    install_requires=read_requirements("base.txt"),
     extras_require={
-        'monitoring': monitoring_extras_require,
-        'bigquery': bigquery_extras_require,
-        'log': log_extras_require
+        'monitoring': read_requirements("monitoring_extras.txt"),
+        'bigquery': read_requirements("bigquery_extras.txt"),
+        'log': read_requirements("log_extras.txt"),
     },
     scripts=["scripts/bf", "scripts/bigflow"]
 )

--- a/test/example_project/main_package/job.py
+++ b/test/example_project/main_package/job.py
@@ -1,8 +1,10 @@
-class ExampleJob:
+import bigflow
+
+class ExampleJob(bigflow.Job):
     def __init__(self, id):
         self.id = id
         self.retry_count = 10
         self.retry_pause_sec = 10
 
-    def run(self, runtime):
+    def execute(self, context: bigflow.JobContext):
         pass

--- a/test/test_interactive.py
+++ b/test/test_interactive.py
@@ -287,7 +287,7 @@ class InteractiveComponentToJobTestCase(TestCase):
             self.assertEqual(ds1._peek_limit, None)
 
         # when
-        fake_component.to_job().execute(bigflow.JobContext.make(runtime_as_str='2019-01-01'))
+        fake_component.to_job().execute(bigflow.JobContext.make(runtime_str='2019-01-01'))
 
 
 class InteractiveComponentRunTestCase(TestCase):

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -1,6 +1,8 @@
+import datetime
 from unittest import TestCase
 import mock
 
+import bigflow
 from bigflow.bigquery.interactive import DatasetConfigInternal
 from bigflow.bigquery.job import Job
 
@@ -22,7 +24,7 @@ class JobTestCase(TestCase):
                 'internal_tables': ['some_internal_table'],
                 'external_tables': {'some_external_table': 'some.external.table'},
                 'extras': {'extra_param': 'some-extra-param'},
-                'runtime': '2019-01-01',
+                'runtime': '2019-01-01 00:00:00',
                 'credentials': 'credentials',
                 'location': 'EU'
             })
@@ -35,7 +37,7 @@ class JobTestCase(TestCase):
                 'external_tables': {'some_external_table': 'some.external.table'},
                 'extras': {'extra_param': 'some-extra-param'},
                 'credentials': 'credentials',
-                'runtime': '2019-01-01',
+                'runtime': '2019-01-01 00:00:00',
                 'location': 'EU'
             })
 
@@ -56,4 +58,4 @@ class JobTestCase(TestCase):
                       extras={'extra_param': 'some-extra-param'}))
 
         # when
-        job.run('2019-01-01')
+        job.execute(bigflow.JobContext.make(runtime=datetime.date(2019, 1, 1)))

--- a/test/test_module/Unused1.py
+++ b/test/test_module/Unused1.py
@@ -22,7 +22,7 @@ class ExampleJob:
     def __init__(self, id):
         self.id = id
 
-    def run(self, runtime):
+    def execute(self, context):
         started_jobs.append(self.id)
 
 workflow_1 = bf.Workflow(workflow_id="ID_1", definition=[wait_for_requests.to_job(), wait_for_requests.to_job()], schedule_interval="@once")

--- a/test/test_monitoring.py
+++ b/test/test_monitoring.py
@@ -1,6 +1,7 @@
 from unittest import TestCase, mock
 from datetime import datetime
 
+import bigflow
 from bigflow import monitoring
 from freezegun import freeze_time
 
@@ -221,7 +222,7 @@ class MeterJobRunFailuresTestCase(TestCase):
 
         # when
         with self.assertRaises(Exception):
-            metered_job.run('2019-01-01')
+            metered_job.execute(bigflow.JobContext.make(runtime='2019-01-01'))
 
         # then
         increment_job_failure_count_mock.assert_called_once_with(monitoring_config, 'job1')

--- a/test/test_monitoring.py
+++ b/test/test_monitoring.py
@@ -203,7 +203,7 @@ class FailingJob(object):
     def __init__(self, id):
         self.id = id
 
-    def run(self, runtime):
+    def execute(self, context):
         raise Exception('Panic!')
 
 

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -16,11 +16,17 @@ class WorkflowTestCase(TestCase):
         workflow = Workflow(workflow_id='test_workflow', definition=definition)
 
         # when
-        workflow.run('2019-01-01')
+        workflow.run(datetime.datetime(2019, 1, 1))
 
         # then
         for step in definition:
-            step.assert_has_calls([mock.call.run(runtime='2019-01-01')])
+            step.assert_has_calls([
+                mock.call.execute(JobContext(
+                    runtime=datetime.datetime(2019, 1, 1),
+                    runtime_as_str='2019-01-01 00:00:00',
+                    workflow=workflow,
+                )),
+            ])
 
     def test_should_run_single_job(self):
         # given

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -23,7 +23,7 @@ class WorkflowTestCase(TestCase):
             step.assert_has_calls([
                 mock.call.execute(JobContext(
                     runtime=datetime.datetime(2019, 1, 1),
-                    runtime_as_str='2019-01-01 00:00:00',
+                    runtime_str='2019-01-01 00:00:00',
                     workflow=workflow,
                 )),
             ])
@@ -66,7 +66,7 @@ class WorkflowTestCase(TestCase):
         ((ctx,), _kwargs) = first_job.execute.call_args
 
         self.assertIs(ctx.workflow, workflow)
-        self.assertEqual(ctx.runtime_as_str, "2020-01-01")
+        self.assertEqual(ctx.runtime_str, "2020-01-01")
         self.assertEqual(ctx.runtime, datetime.datetime(2020, 1, 1))
 
     def test_should_run_single_classbased_job_oldapi(self):

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -24,7 +24,7 @@ class WorkflowTestCase(TestCase):
 
     def test_should_run_single_job(self):
         # given
-        first_job = mock.Mock(spec={'run', 'id'})
+        first_job = mock.Mock(spec_set=['run', 'id'])
         first_job.id = 'first job'
         first_job.run = mock.Mock()
 
@@ -42,7 +42,7 @@ class WorkflowTestCase(TestCase):
 
     def test_should_run_single_job_with_context(self):
         # given
-        first_job = mock.Mock(spec={'execute', 'run', 'id'})
+        first_job = mock.Mock(spec_set=['execute', 'run', 'id'])
         first_job.id = 'first job'
         first_job.execute = mock.Mock()
 
@@ -57,7 +57,7 @@ class WorkflowTestCase(TestCase):
             step.assert_not_called()
 
         first_job.execute.assert_called_once()
-        ctx: bigflow.workflow.JobContext = first_job.execute.call_args.args[0]
+        ((ctx,), _kwargs) = first_job.execute.call_args
 
         self.assertIs(ctx.workflow, workflow)
         self.assertEqual(ctx.workflow_id, workflow.workflow_id)

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -60,8 +60,7 @@ class WorkflowTestCase(TestCase):
         ((ctx,), _kwargs) = first_job.execute.call_args
 
         self.assertIs(ctx.workflow, workflow)
-        self.assertEqual(ctx.workflow_id, workflow.workflow_id)
-        self.assertEqual(ctx.runtime_raw, "2020-01-01")
+        self.assertEqual(ctx.runtime_as_str, "2020-01-01")
         self.assertEqual(ctx.runtime, datetime.datetime(2020, 1, 1))
 
     def test_should_run_single_classbased_job_oldapi(self):
@@ -104,8 +103,7 @@ class WorkflowTestCase(TestCase):
         context: JobContext = first_job.context
         self.assertIsNotNone(context)
         self.assertEqual(context.runtime, datetime.datetime(2020, 1, 1))
-        self.assertEqual(context.workflow, workflow)
-        self.assertEqual(context.workflow_id, 'test_workflow')
+        self.assertIs(context.workflow, workflow)
 
     def test_should_have_id_and_schedule_interval(self):
         # given


### PR DESCRIPTION
Extend Job api.

When job has method 'execute', it is executed with 'workflow' object, runtime (parsed as datetime), workflow id
Otherwise the old method 'run(runtime)' is executed.  This change does not break all existing jobs.
Eventually we may deprecate/remove method 'run' from jobs.