### PR TITLE
Use default 'google.cloud.logging' Handler

### DIFF
--- a/bigflow/log.py
+++ b/bigflow/log.py
@@ -154,6 +154,8 @@ def init_logging(config: LogConfigDict, workflow_id: str, banner=True):
     # Disable logs from 'google.cloud.logging'
     gclogging_logger = logging.getLogger("google.cloud.logging")
     gclogging_logger.setLevel(logging.WARNING)
+    gclogging_logger.propagate = False
+    gclogging_logger.addHandler(logging.StreamHandler())
 
     # TODO: add formatter?
     root.addHandler(gcp_logger_handler)

--- a/bigflow/log.py
+++ b/bigflow/log.py
@@ -32,6 +32,7 @@ def create_gcp_log_handler(
 ):
     client = google.cloud.logging.Client(project=project_id)
     handler = google.cloud.logging.handlers.CloudLoggingHandler(client, name=log_name, labels=labels)
+    handler.addFilter(lambda r: not r.name.startswith("google.cloud.logging"))
     return handler
 
 
@@ -153,6 +154,10 @@ def init_logging(config: LogConfigDict, workflow_id: str, banner=True):
                ***********************************************************"""))
     gcp_logger_handler = create_gcp_log_handler(gcp_project_id, log_name, labels)
     gcp_logger_handler.setLevel(log_level or logging.INFO)
+
+    # Disable logs from 'google.cloud.logging'
+    gclogging_logger = logging.getLogger("google.cloud.logging")
+    gclogging_logger.setLevel(logging.WARNING)
 
     # TODO: add formatter?
     root.addHandler(gcp_logger_handler)

--- a/bigflow/log.py
+++ b/bigflow/log.py
@@ -2,7 +2,6 @@ import logging
 import typing
 import sys
 import uuid
-import traceback
 
 from textwrap import dedent
 
@@ -10,9 +9,6 @@ import bigflow
 
 import google.cloud.logging
 import google.cloud.logging.handlers
-
-from google.cloud import logging_v2
-from google.cloud.logging_v2.gapic.enums import LogSeverity
 
 from urllib.parse import quote_plus
 


### PR DESCRIPTION
 - Send all log events from background thread
 - Pack logs in batches (up to 1k elements)
 - Handle log timestamps
 - Autodetect current GCP project id