### PR TITLE
Refactor, modules cleanup

### DIFF
--- a/bigflow/__init__.py
+++ b/bigflow/__init__.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import inspect
 import warnings
 import importlib
 
@@ -20,17 +21,23 @@ __all__ = [
 ]
 
 
+# TODO(anjensan): Remove at 1.0
 def __getattr__(name):
+    if "importlib" in inspect.stack()[1].filename:
+        # Skip imports like 'from bigflow import xxx'
+        raise AttributeError
+
     if name in {
         'bigquery',
         'monitoring',
         'resources',
     }:
         importlib.import_module(f"bigflow.{name}")
-        msg = f"Don't use `bigflow.{name}` directly, add explicit import `import bigflow.{name}` instead"
+        msg = f"Module `bigflow.{name}` should be explicitly imported with `import bigflow.{name}`"
         warnings.warn(msg, DeprecationWarning)
         print("!!!", msg, file=sys.stderr)
         return globals()[name]
+
     raise AttributeError
 
 

--- a/bigflow/__init__.py
+++ b/bigflow/__init__.py
@@ -21,13 +21,11 @@ __all__ = [
 
 try:
     from . import bigquery
-    __all__.append('bigquery')
 except ImportError:
     pass
 
 try:
     from . import monitoring
-    __all__.append('monitoring')
 except ImportError:
     pass
 

--- a/bigflow/__init__.py
+++ b/bigflow/__init__.py
@@ -4,7 +4,6 @@ import json
 import warnings
 import importlib
 
-from . import resources
 from .workflow import Workflow, Definition, Job, JobContext
 from .configuration import Config
 
@@ -28,9 +27,11 @@ def __getattr__(name):
         'resources',
     }:
         importlib.import_module(f"bigflow.{name}")
-        msg = f"Don't use `bigflow.{name}` directly, add explicit import `from bigflow import {name}` instead"
+        msg = f"Don't use `bigflow.{name}` directly, add explicit import `import bigflow.{name}` instead"
         warnings.warn(msg, DeprecationWarning)
         print("!!!", msg, file=sys.stderr)
+        return globals()[name]
+    raise AttributeError
 
 
 def _maybe_init_logging_from_env():

--- a/bigflow/__init__.py
+++ b/bigflow/__init__.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import json
+import warnings
+import importlib
 
 from . import resources
 from .workflow import Workflow, Definition, Job, JobContext
@@ -16,18 +18,19 @@ __all__ = [
     'JobContext',
     'Definition',
     'Config',
-    'resources'
 ]
 
-try:
-    from . import bigquery
-except ImportError:
-    pass
 
-try:
-    from . import monitoring
-except ImportError:
-    pass
+def __getattr__(name):
+    if name in {
+        'bigquery',
+        'monitoring',
+        'resources',
+    }:
+        importlib.import_module(f"bigflow.{name}")
+        msg = f"Don't use `bigflow.{name}` directly, add explicit import `from bigflow import {name}` instead"
+        warnings.warn(msg, DeprecationWarning)
+        print("!!!", msg, file=sys.stderr)
 
 
 def _maybe_init_logging_from_env():

--- a/bigflow/bigquery/__init__.py
+++ b/bigflow/bigquery/__init__.py
@@ -1,17 +1,14 @@
-try:
-    from .interactive import interactive_component as component
-    from .interactive import add_label, sensor, INLINE_COMPONENT_DATASET_ALIAS
-    from .dataset_configuration import DatasetConfig
-    from .job import Job
-    from .interface import Dataset
-    __all__ = [
-        'component',
-        'add_label',
-        'sensor',
-        'INLINE_COMPONENT_DATASET_ALIAS',
-        'DatasetConfig',
-        'Job'
-    ]
-except ImportError:
-    __all__ = []
+from .interactive import interactive_component as component
+from .interactive import add_label, sensor, INLINE_COMPONENT_DATASET_ALIAS
+from .dataset_configuration import DatasetConfig
+from .job import Job
+from .interface import Dataset
 
+__all__ = [
+    'component',
+    'add_label',
+    'sensor',
+    'INLINE_COMPONENT_DATASET_ALIAS',
+    'DatasetConfig',
+    'Job'
+]

--- a/bigflow/bigquery/interactive.py
+++ b/bigflow/bigquery/interactive.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import functools
 import hashlib
 import logging

--- a/bigflow/scaffold/__init__.py
+++ b/bigflow/scaffold/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 __all__ = ['start_project']
 
 from .scaffold import start_project

--- a/e2e/config.py
+++ b/e2e/config.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 PROJECT_ID = None
 CREDENTIALS = None
 

--- a/e2e/test_dataset_manager.py
+++ b/e2e/test_dataset_manager.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from unittest import TestCase
 from unittest import main
 import uuid

--- a/e2e/test_dataset_manager.py
+++ b/e2e/test_dataset_manager.py
@@ -4,7 +4,7 @@ import uuid
 
 import pandas as pd
 
-from bigflow import create_dataset_manager
+from bigflow.bigquery import create_dataset_manager
 from . import config
 
 

--- a/test/test_monitoring.py
+++ b/test/test_monitoring.py
@@ -2,7 +2,8 @@ from unittest import TestCase, mock
 from datetime import datetime
 
 import bigflow
-from bigflow import monitoring
+import bigflow.monitoring as monitoring
+
 from freezegun import freeze_time
 
 


### PR DESCRIPTION
This PR contain import-related changes:

  - Remove '__all__' from 'bigflow.bigquery', as names might go into clash with some variables from 'bigflow' namespace.
    It might encourage some users to write "from bigflow import *; from bigflow.bigquery import *"

  - Don't import 'bigquery' and 'monitoring' submodules in bigflow/__init__.py
     It makes library load slightly faster (important for CLI), easier to understand/read the sourcecode.
     Lazy-importing via "__getattr__" added in order to keep backward compatability.

  - Drop all "from __future__ import absolute_import" - noop for Py3