### PR TITLE
Add TestCase mixins to isolate test into subprocess

### DIFF
--- a/bigflow/testing/__init__.py
+++ b/bigflow/testing/__init__.py
@@ -1,0 +1,9 @@
+from bigflow.testing.isolate import (
+    ForkIsolateMixin,
+    SpawnIsolateMixin,
+)
+
+__all__ = [
+    'ForkIsolateMixin',
+    'SpawnIsolateMixin',
+]

--- a/bigflow/testing/isolate.py
+++ b/bigflow/testing/isolate.py
@@ -1,0 +1,218 @@
+"""Mixins to isolate `unittest.TestCase` into separate processes
+
+May prevent from doing side effects with Python intepreter
+(loaded modules, global variables, caches etc).
+"""
+
+import unittest
+import sys
+import time
+import contextlib
+import multiprocessing
+import threading
+
+
+class _ObjectTag:
+    """Stub for non-pickable objects, which needed to be transferred between processes"""
+
+    def __init__(self, tag):
+        self.tag = tag
+
+    @classmethod
+    def forfeit(cls, obj, obj2tag):
+        return cls(obj2tag[obj]) if obj in obj2tag else obj
+
+    @classmethod
+    def recover(cls, obj, tag2obj):
+        return tag2obj[obj.tag] if isinstance(obj, cls) else obj
+
+
+class _TestResultProxy:
+    """Dump proxy for `TestResult`. Stream all public method calls into channel."""
+
+    def __init__(self, ch, testcase_proxy, tblib):
+        self._ch = ch
+        self._tc_proxy = testcase_proxy
+        self._tblib = tblib
+        self._lock = threading.Lock()
+
+    # proxy all public method calls
+    def __getattr__(self, name: str):
+        assert not name.startswith("_")
+
+        def method(*args):
+            with self._lock:
+                # replace ref to proxy testcase by sepulka
+                smap = {self._tc_proxy: 'testcase'}
+                args = [_ObjectTag.forfeit(a, smap) for a in args]
+
+                if isinstance(args[-1], tuple) and not self._tblib:
+                    # last arg is 'exc_info', but `tblib` is not installed
+                    args[-1] = (None, None, None)
+
+                self._ch.send((name, tuple(args)))
+                return self._ch.recv()
+
+        return method
+
+
+class _IsolatedProcessMixin(unittest.TestCase):
+
+    test_timeout: float
+    _isolated_test_spawn_method: str
+
+    def _enable_tblib(self):
+        try:
+            import tblib.pickling_support
+        except ImportError:
+            print("Failed to import `tblib`, tracebask/stacktracs might be stripped")
+            return False
+        else:
+            tblib.pickling_support.install()
+            return True
+
+    def _stop_process(self, p):
+        if p.is_alive():
+            p.kill()
+            p.join(timeout=30)
+        p.close()
+
+    def _fail_into_result(self, result: unittest.TestResult, msg):
+        """Include error with the traceback into `TestResult`"""
+        try:
+            raise RuntimeError(msg)
+        except RuntimeError:
+            result.addFailure(self, sys.exc_info())
+
+    def run0(self, ch, tblib):
+        tblib = tblib and self._enable_tblib()  # enable in child process
+        with ch:
+            super().run(_TestResultProxy(ch, self, tblib))
+            ch.send(('__stop__', None))
+
+    def _recv_testresult_proxy(self, result, process, ch, run_until):
+        """Recieve and applly method calls on real TestResult object"""
+
+        poll_delay = 0.001
+        while process.is_alive() and time.time() < run_until:
+            if not ch.poll(poll_delay):
+                poll_delay = min(1, poll_delay * 1.5)
+                continue
+
+            poll_delay = 0.001
+            method, args = ch.recv()
+            if method == '__stop__':
+                return  # ok
+
+            # recover ref to current testcase
+            smap = {'testcase': self}
+            args = tuple(_ObjectTag.recover(a, smap) for a in args)
+
+            resp = getattr(result, method)(*args)
+            ch.send(resp)
+
+        if process.is_alive():
+            self._fail_into_result(result, "Timeout: isolated test subprocess is stil running")
+        else:
+            self._fail_into_result(result, "Isotalted process was unexpectedly terminated")
+
+    def run(self, result=None):
+        tblib = self._enable_tblib()
+
+        if result is None:
+            result = self.defaultTestResult()
+        mp_context = multiprocessing.get_context(
+            self._isolated_test_spawn_method)
+
+        self.setUpParent()
+        with contextlib.ExitStack() as cstack:
+            cstack.callback(self.tearDownParent)
+
+            server_ch, client_ch = mp_context.Pipe()
+            cstack.callback(server_ch.close)
+            cstack.callback(client_ch.close)
+
+            process = mp_context.Process(
+                name=f"isolated-test--{self.id}",
+                target=self.run0, args=[client_ch, tblib],
+            )
+            process.start()
+            cstack.callback(self._stop_process, process)
+
+            run_until = time.time() + self.test_timeout
+            self._recv_testresult_proxy(result, process, server_ch, run_until)
+            process.join(max(1, run_until - time.time()))
+
+    def setUpParent(self):
+        "Hook method for setting up the test fixture before exercising it. Runs in original python process."
+        pass
+
+    def tearDownParent(self):
+        "Hook method for deconstructing the test fixture after testing it. Runs in original python process."
+        pass
+
+
+class ForkIsolateMixin(_IsolatedProcessMixin):
+    """Mixin class for subclasses of `unittest.TestCase`
+
+    Run all test methods in separate forked processes.
+    All changes in variables/modules/memory made during test execution does not affect original Python instance.
+    Note, that IO operations are not isolated, so external resources still need to be cleaned manually.
+
+    Methods `setUpClass` and `tearDownClass` are executed in scope of main process.
+
+    Methods `setUp` and `tearDown` are executed inside spawned process.
+    Additional methods `setUpParent` and `tearDownParent` provided to run
+    per-test fixtures in scope of parent process.
+    """
+
+    test_timeout: float = 600
+
+    _isolated_test_spawn_method = 'fork'
+
+
+class SpawnIsolateMixin(_IsolatedProcessMixin):
+    """Mixin class for subclasses of `unittest.TestCase`
+
+    Run all test methods in fresh Python processes.
+    Each process is inializated 'from scratch', which result into recreating/reloading all modules/classes.
+    Note, that IO operations are not isolated, so external resources still need to be cleaned manually.
+
+    Methods `setUpClass` and `tearDownClass` are executed in scope of main process,
+    however it is not recommended to use them with this mixin.
+
+    Methods `setUp` and `tearDown` are executed inside spawned process.
+    Additional methods `setUpParent` and `tearDownParent` provided to run
+    per-test fixtures in scope of parent process.
+
+    Test instance and test class must be pickleable.
+    """
+
+    test_timeout: float = 600
+
+    _isolated_test_spawn_method = 'spawn'
+
+    def __init__(self, *args, **kwargs):
+        self._class_dict_orig = dict(self.__class__.__dict__)
+        super().__init__(*args, **kwargs)
+
+    # Pickle not only test instance state, but also state of test class
+    # Only fields changed after test `__init__` are tranferred into subprocess.
+    def __getstate__(self):
+        selfdict = dict(self.__dict__)
+        clsdict_orig = selfdict.pop('_class_dict_orig')
+        clsdict = {
+            k: v
+            for k, v in self.__class__.__dict__.items()
+            if k not in clsdict_orig or clsdict_orig[k] is not v
+        }
+        return selfdict, clsdict
+
+    def __setstate__(self, state):
+
+        selfdict, clsdict = state
+        self.__dict__ = selfdict
+
+        # dynamically overwrite test class with new state
+        pcls = type(self.__class__.__name__, (self.__class__,), clsdict)
+        self.__class__ = pcls

--- a/bigflow/testing/isolate.py
+++ b/bigflow/testing/isolate.py
@@ -134,14 +134,13 @@ class _IsolatedProcessMixin(unittest.TestCase):
             self._fail_into_result(result, "Isotalted process was unexpectedly terminated")
 
     def run(self, result=None):
-
         cls = type(self)
-        assert not cls._was_executed, "Test was already executed without isolation, either enable isolation or run single test at once"
 
         if not self.isolate:
+            assert not cls._was_executed, "Test was already executed without isolation, either enable isolation or run single test at once"
             try:
                 self.setUpParent()
-                super().run(result)
+                return super().run(result)
             finally:
                 self.tearDownParent()
 

--- a/bigflow/testing/isolate.py
+++ b/bigflow/testing/isolate.py
@@ -4,6 +4,19 @@ May prevent from doing side effects with Python intepreter
 (loaded modules, global variables, caches etc).
 """
 
+# `*IsolateMixin`s overrides original `unittest.TestCase.run` method.
+# It spawns a new subprocess via `multiprocessing`.
+# With 'spawn' strategy the whole unittest is pickled and passend into subprocess.
+# With 'fork' strategy pickling is not involved.
+#
+# Then parent creates proxy to instance of `unittest.TestResult` and pass proxy to
+# child process.  Such synchronously sends information about all methods calls
+# to parent via duplex pipe.  Parent recieves information and mutate
+# original 'TestResult' appropriately.
+#
+# You can find sequence diagramm for this in "isolate_sequence.puml" file.
+
+
 import unittest
 import sys
 import time

--- a/bigflow/testing/isolate_sequence.puml
+++ b/bigflow/testing/isolate_sequence.puml
@@ -1,0 +1,83 @@
+@startuml Sequence diagramm for mixins from `bigflow.testing.isolate`
+' View diagram with http://www.plantuml.com/plantuml
+
+box "parent process" #lightcyan
+    participant Runner
+    participant TestResult #LightGreen
+    participant TestCase #LightPink
+    participant "_TestResultProxy" as _TestResultProxy #LightGreen
+end box
+
+box "child process" #moccasin
+    participant "_TestResultProxy" as _TestResultProxy2 <<clone>> #LightGreen
+    participant "TestCase" as TestCase2 <<clone>> #LightPink
+end box
+
+activate Runner
+Runner -> TestResult ** : <<create>>
+
+Runner -> TestCase : TestClass.setUpClass()
+activate TestCase #skyblue
+deactivate
+|||
+
+Runner -> TestCase ** : <<create>>
+Runner -> TestCase ++ : run(testResult)
+
+TestCase -> TestCase : setUpParent()
+activate TestCase  #skyblue
+deactivate
+
+TestCase -> _TestResultProxy **: <<create>>
+
+TestCase ->> TestCase2: spawn/fork child process
+|||
+
+_TestResultProxy -->> _TestResultProxy2 ** : <<clone>>
+TestCase -->> TestCase2 ** : <<clone>>
+
+TestCase --> TestCase2 ++ : run0(resultProxy)
+TestCase -> TestCase ++ : recieve from pipe
+
+TestCase2 -> TestCase2 : setUp()
+activate TestCase2  #skyblue
+deactivate
+
+TestCase2 -> TestCase2: runTest()
+
+activate TestCase2 #dodgerblue
+    |||
+    TestCase2 -> _TestResultProxy2 ++ : report fail/success
+    _TestResultProxy2 --> TestCase ++ : send (method name, args) over pipe
+
+    TestCase -> TestResult ++ : apply method with args
+    return
+
+    TestCase --> _TestResultProxy2 -- : ack over pipe
+    _TestResultProxy2 -> TestCase2 --
+deactivate TestCase2
+
+TestCase2 -> TestCase2 : tearDown()
+activate TestCase2 #skyblue
+deactivate
+
+TestCase2 --> TestCase --: send ("~__stop__", None) over pipe
+TestCase -> TestCase --
+
+TestCase -> TestCase : tearDownParent()
+activate TestCase #skyblue
+deactivate
+
+TestCase -> Runner --
+
+Runner -> TestCase : TestCase.tearDownClass()
+activate TestCase #skyblue
+deactivate
+|||
+
+Runner -> TestResult ++ :  print
+return
+
+deactivate Runner
+
+@enduml

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,3 +5,5 @@ apache-airflow>=1.10
 nose==1.3.7
 mock==4.0.2
 responses~=0.12.1
+
+tblib===1.7.0

--- a/test/testing/nonpure.py
+++ b/test/testing/nonpure.py
@@ -1,0 +1,2 @@
+import uuid
+CONST = uuid.uuid4()

--- a/test/testing/test_isolate.py
+++ b/test/testing/test_isolate.py
@@ -1,0 +1,107 @@
+import os
+import unittest
+
+import tblib  # ensure installed
+
+import bigflow.testing
+
+from . import nonpure
+
+
+class TestIsolateMixinTestCase(unittest.TestCase):
+
+    class SubTest(unittest.TestCase):
+        failed = False
+
+        @classmethod
+        def setUpClass(cls):
+            cls.pid = os.getpid()
+
+        def test_fail(self):
+            type(self).failed = True
+            self.fail('fail-ok')
+
+        def test_ok(self):
+            self.assertNotEqual(self.pid, os.getpid())
+
+        def test_error(self):
+            raise RuntimeError('fail-error')
+
+        @unittest.skip('test-skip')
+        def test_skip(self):
+            self.fail()
+
+        @unittest.expectedFailure
+        def test_expected_failure_but(self):
+            pass
+
+        @unittest.expectedFailure
+        def test_expected_failure(self):
+            self.fail("expected")
+
+    class ForkTest(bigflow.testing.ForkIsolateMixin, SubTest):
+        pass
+
+    class SpawnTest(bigflow.testing.SpawnIsolateMixin, SubTest):
+        pass
+
+    def check_test_mixin_subtest(self, test_class):
+        # when
+        result = self._run_test(test_class)
+
+        # then
+        self.assertEqual(6, result.testsRun, "All tests should run")
+
+        # then
+        self.assertEqual(1, len(result.failures))
+        self.assertRegex(result.failures[0][0].id(), r".*\.test_fail", "Test 'test_fail' sould fail")
+        self.assertIsNotNone(result.failures[0][1], "Traceback is attached")
+        self.assertFalse(test_class.failed, "State is not propogated")
+
+        # then]
+        self.assertEqual(1, len(result.errors))
+        self.assertRegex(result.errors[0][0].id(), ".*\.test_error", "Test 'test_error' sould raise exception")
+        self.assertIsNotNone(result.errors[0][1], "Traceback is attached")
+
+        # then
+        self.assertEqual(1, len(result.skipped), "Single skipped test")
+        self.assertEqual(1, len(result.unexpectedSuccesses), "Single unexpected success")
+        self.assertEqual(1, len(result.expectedFailures), "Single expected failure")
+
+    def _run_test(self, test_class):
+        devnull = open(os.devnull, 'wt')
+        self.addCleanup(devnull.close)
+        runner = unittest.TextTestRunner(stream=devnull)
+        suite = unittest.defaultTestLoader.loadTestsFromTestCase(test_class)
+        return runner.run(suite)
+
+    @unittest.skip
+    def test_fork_mixin(self):
+        self.check_test_mixin_subtest(self.ForkTest)
+
+    def test_spawn_mixin(self):
+        self.check_test_mixin_subtest(self.SpawnTest)
+
+
+class ForkReloadModulesTest(
+    bigflow.testing.ForkIsolateMixin,
+    unittest.TestCase,
+):
+    def setUpParent(self):
+        self.const = nonpure.CONST
+
+    def runTest(self):
+        from . import nonpure
+        self.assertEqual(self.const, nonpure.CONST, "Module should not be reloaded")
+
+
+class SpawnReloadModulesTest(
+    bigflow.testing.SpawnIsolateMixin,
+    unittest.TestCase,
+):
+    def setUpParent(self):
+        self.const = nonpure.CONST
+
+    def runTest(self):
+        from . import nonpure
+        self.assertNotEqual(self.const, nonpure.CONST, "Module should be reloaded")


### PR DESCRIPTION
Mixin `SpawnIsolateMixin` might be used to create base class for e2e tests (see #169)
Mixin `ForkIsolateMixin` is helpful when tested code might change some "hidden" state: in-memory caches, buffers, imported modules etc.