### PR TITLE
Always include 'setup.py' into sdist

### DIFF
--- a/bigflow/build/dist.py
+++ b/bigflow/build/dist.py
@@ -142,6 +142,7 @@ class sdist(distutils.command.sdist.sdist):
     def _add_defaults_bigflow(self):
         self.filelist.extend(
             filter(os.path.exists, [
+                "setup.py",
                 "pyproject.toml",
                 "deployment_config.py",
                 "requirements.in",


### PR DESCRIPTION
setuptools may not include `setup.py` into
manifest when package is intalled from .tar