### PR TITLE
Use custom docker image on Dataflow workers

### DIFF
--- a/bigflow/dataflow.py
+++ b/bigflow/dataflow.py
@@ -101,6 +101,9 @@ class BeamJob(Job):
                 drop_default=True,
                 retain_unknown_options=True,
             )
+            pipeline_options2 = PipelineOptions.from_dictionary(pipeline_options).get_all_options(
+                drop_default=True, retain_unknown_options=True)
+            assert pipeline_options == pipeline_options2, "During convertsion PipelineOptions<>dict some parameters was gone"
 
         self.pipeline_options = dict(pipeline_options or {})
         assert PipelineOptions.from_dictionary(self.pipeline_options)

--- a/bigflow/dataflow.py
+++ b/bigflow/dataflow.py
@@ -1,12 +1,18 @@
 import typing
 import logging
+import uuid
 
 from apache_beam import Pipeline
-from apache_beam.options.pipeline_options import PipelineOptions, GoogleCloudOptions
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.runners.runner import PipelineResult, PipelineState
 
-from bigflow.commons import public
+from typing import Dict, Union
+
+from bigflow.commons import public, build_docker_image_tag
 from bigflow.workflow import Job, JobContext
-from bigflow.workflow import DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS, DEFAULT_PIPELINE_LEVEL_EXECUTION_TIMEOUT_SHIFT_IN_SECONDS
+
+import bigflow.build.reflect
+
 
 logger = logging.getLogger(__file__)
 
@@ -14,56 +20,124 @@ logger = logging.getLogger(__file__)
 @public()
 class BeamJob(Job):
 
+    pipeline_level_execution_timeout_shift = 120  # 2 minutes
+
     def __init__(
             self,
-            id: str,
-            entry_point: typing.Callable[[Pipeline, JobContext, dict], None],
-            pipeline_options: PipelineOptions = None,
+            id: str = None,
+            entry_point: typing.Callable[[Pipeline, JobContext, dict], None] = None,
+            pipeline_options: Union[typing.Dict, PipelineOptions, None] = None,
             entry_point_arguments: typing.Optional[dict] = None,
             wait_until_finish: bool = True,
-            execution_timeout_sec: int = DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS,
             test_pipeline: Pipeline = None,
+            execution_timeout_sec: int = None,
+            use_docker_image: typing.Union[str, bool] = False,
+            project_name=None,
+            **kwargs,
     ):
         if bool(test_pipeline) == bool(pipeline_options):
             raise ValueError("One of the pipeline and pipeline_options must be provided.")
+
         if not wait_until_finish and execution_timeout_sec:
             raise ValueError("If wait_until_finish_set to False execution_timeout can not be used.")
 
-        self.id = id
+        super().__init__(
+            id=id,
+            execution_timeout_sec=execution_timeout_sec,
+        )
+
+        if isinstance(pipeline_options, PipelineOptions):
+            pipeline_options = pipeline_options.get_all_options(drop_default=True)
+            self._set_default_pipeline_options = False
+        else:
+            self._set_default_pipeline_options = True
+
+        self.pipeline_options = dict(pipeline_options or {})
+        assert PipelineOptions.from_dictionary(self.pipeline_options)
+
         self.entry_point = entry_point
         self.entry_point_arguments = entry_point_arguments
-        self.pipeline_options = pipeline_options
         self.wait_until_finish = wait_until_finish
-        self.pipeline = test_pipeline
-        self.execution_timeout_sec = execution_timeout_sec
-        self.pipeline_level_execution_timeout_shift = DEFAULT_PIPELINE_LEVEL_EXECUTION_TIMEOUT_SHIFT_IN_SECONDS
+        self.test_pipeline = test_pipeline
+
+        self.use_docker_image = use_docker_image
+        self._project_path = bigflow.build.reflect.locate_project_path(project_name)
 
     def execute(self, context: JobContext):
-        if self.pipeline:
-            pipeline = self.pipeline
-        else:
-            if context.workflow:
-                self.pipeline_options = self._apply_logging(self.pipeline_options, context.workflow.workflow_id)
-            else:
-                logger.info("A workflow not found in the context. Skipping logging initialization.")
-            pipeline = self._create_pipeline(self.pipeline_options)
-        self.entry_point(pipeline, context, self.entry_point_arguments)
-        result = pipeline.run()
+        pipeline = self.test_pipeline or self.new_pipeline(context)
+
+        logger.info("init beam pipeline...")
+        self.init_pipeline(context, pipeline)
+
+        logger.info("run beam pipeline...")
+        result = self.run_pipeline(context, pipeline)
+
+        logger.info("wait pipeline result...")
+        self.wait_pipeline_result(result)
+
+    def wait_pipeline_result(self, result: PipelineResult):
         if self.wait_until_finish and self.execution_timeout_sec:
             timeout_in_milliseconds = 1000 * (self.execution_timeout_sec - self.pipeline_level_execution_timeout_shift)
             result.wait_until_finish(timeout_in_milliseconds)
-            if not result.is_in_terminal_state():
+            if not PipelineState.is_terminal(result.state):
                 result.cancel()
                 raise RuntimeError(f'Job {self.id} timed out ({self.execution_timeout_sec})')
 
-    def _create_pipeline(self, options):
-        return Pipeline(options=options)
+    def new_pipeline(self, context):
+        logger.debug("Create new pipline for context %s", context)
+        popts = self.create_pipeline_options(context)
+        return Pipeline(options=popts)
 
-    @staticmethod
-    def _apply_logging(pipeline_options: PipelineOptions, workflow_id: str) -> PipelineOptions:
-        google_cloud_options = pipeline_options.view_as(GoogleCloudOptions)
-        if not google_cloud_options.labels:
-            google_cloud_options.labels = []
-        google_cloud_options.labels.append(f'workflow_id={workflow_id}')
-        return pipeline_options
+    def init_pipeline(self, context, pipeline):
+        if not self.entry_point:
+            raise RuntimeError("You need override method 'init_pipeline' or provide 'entry_point' argument")
+        self.entry_point(pipeline, context, self.entry_point_arguments)
 
+    def run_pipeline(self, context, pipeline):
+        logger.info("Run pipeline, context %s", context)
+        return pipeline.run()
+
+    def create_pipeline_options(self, context: JobContext) -> PipelineOptions:
+        options = dict(self.pipeline_options)
+        if self._set_default_pipeline_options:
+            self.set_default_pipeline_options(options, context)
+        logger.debug("Pipeline options from dict %s", options)
+        return PipelineOptions.from_dictionary(options)
+
+    def set_default_pipeline_options(self, options: Dict, context: JobContext):
+        logger.debug("Add defaults to pipeline options")
+
+        if 'job_name' not in options:
+            slug = self.id.replace("_", "-")
+            job_name = f"{slug}-{uuid.uuid4().hex}"
+            logger.info("Set job name to deafult %s", job_name)
+            options['job_name'] = job_name
+
+        if 'setup_file' not in options:
+            setuppy = bigflow.build.reflect.materialize_setuppy(self._project_path)
+            logging.debug("Add setup.py %s to pipeline options", setuppy)
+            options['setup_file'] = setuppy
+        else:
+            logging.debug("Pipeline options already contains 'setup_file': %s", options['setup_file'])
+
+        workflow_id = context.workflow_id
+        if workflow_id:
+            options['labels'] = (options.get('labels') or []) + [f'workflow_id={workflow_id}']
+        else:
+            logger.warning("A workflow_id is not found in the context - skip logging initialization.")
+
+        if self.use_docker_image:
+            if isinstance(self.use_docker_image, str):
+                logger.debug("Use explicitly provided docker image")
+                imgid = self.use_docker_image
+            else:
+                logger.debug("Infer docker image name for current project")
+                pspec = bigflow.build.reflect.get_project_spec(self._project_path)
+                imgid = build_docker_image_tag(pspec.docker_repository, pspec.version)
+            logger.info("Use docker image %s for beam workers", imgid)
+
+            options['worker_harness_container_image'] = imgid
+            experiments = options.setdefault('experiments', [])
+            if 'use_runner_v2' not in experiments:
+                logger.info("Enable beam experiment 'use_runner_v2'")
+                experiments.append('use_runner_v2')

--- a/bigflow/workflow.py
+++ b/bigflow/workflow.py
@@ -113,7 +113,26 @@ class Job(abc.ABC):
     id: str
     retry_count: int = 3
     retry_pause_sec: int = 60
-    execution_timeout_sec: int = DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS
+    execution_timeout_sec: int = 10800  # 3 hours
+
+    def __init__(
+        self,
+        id=None,
+        execution_timeout_sec=None,
+        retry_count=None,
+        retry_pause_sec=None,
+    ):
+        if id is not None:
+            self.id = id
+
+        if execution_timeout_sec is not None:
+            self.execution_timeout_sec = execution_timeout_sec
+
+        if retry_count is not None:
+            self.retry_count = retry_count
+
+        if retry_pause_sec is not None:
+            self.retry_pause_sec = retry_pause_sec
 
     @abc.abstractmethod
     def execute(self, context: JobContext):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,6 +7,7 @@ pip-tools>=5.3,<7
 deprecated>=1.2.10,<2
 toml>=0.10
 tblib>=1.7,<2
+typing-extensions~=3.7;python_version<="3.7"
 
 wheel>=0.35
 setuptools>=45

--- a/test/test_dataflow.py
+++ b/test/test_dataflow.py
@@ -1,3 +1,4 @@
+from os import pipe
 from unittest import TestCase
 from unittest import mock
 import unittest
@@ -8,54 +9,45 @@ from apache_beam import Pipeline
 from apache_beam.options.pipeline_options import PipelineOptions, GoogleCloudOptions
 from apache_beam.runners.portability.fn_api_runner.fn_runner import RunnerResult
 from apache_beam.testing.test_pipeline import TestPipeline
-from collections import defaultdict
+from collections import defaultdict, Counter
 from bigflow import JobContext, Workflow
+from bigflow import dataflow
 
 from bigflow.dataflow import BeamJob
 from bigflow.workflow import DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS, DEFAULT_PIPELINE_LEVEL_EXECUTION_TIMEOUT_SHIFT_IN_SECONDS
 
 
-class CountWordsFn(beam.DoFn):
-    def __init__(self, CounterState):
-        super().__init__()
-        self.CounterState = CounterState
-
-    def process(self, element, *args, **kwargs):
-        word, count = element
-        self.CounterState.counter[word] += len(count)
-        yield word, len(count)
-
-
-class CounterState(object):
-    counter = defaultdict(int)
-
-
-class CounterStater(beam.PTransform):
-    def __init__(self, CounterState):
-        super().__init__()
-        self.CounterState = CounterState
-
-    def expand(self, records_to_delete):
-        return records_to_delete \
-               | "CounterStateCountedWords" >> beam.ParDo(
-            CountWordsFn(self.CounterState))
-
-
 class CountWordsDriver:
-    def __init__(self, CounterStater):
-        self.result = None
+
+    counter = Counter()
+
+    def __init__(self):
         self.context = None
         self.pipeline = None
-        self.CounterStater = CounterStater
+        self.counter.clear()
+
+    @staticmethod
+    def count(word, counts):
+        CountWordsDriver.counter[word] += sum(counts)
+
+    def run_ex(self, pipeline, context, words_to_count, words_to_filter):
+        self.pipeline = pipeline
+        self.context = context
+        return (
+            pipeline
+            | 'LoadingWordsInput' >> beam.Create(words_to_count)
+            | 'FilterWords'       >> beam.Filter(lambda w: w in words_to_filter)
+            | 'MapToCount'        >> beam.Map(lambda w: (w, 1))
+            | 'GroupWords'        >> beam.GroupByKey()
+            | 'Count'             >> beam.MapTuple(self.count)
+        )
 
     def run(self, pipeline: Pipeline, context: JobContext, driver_arguments: dict):
-        words_input = pipeline | 'LoadingWordsInput' >> beam.Create(driver_arguments['words_to_count'])
-        words_input | 'FilterWords' >> (beam.Filter(lambda w: w in driver_arguments['words_to_filter'])
-                                        | 'MapToCount' >> beam.Map(lambda w: (w, 1))
-                                        | 'GroupWords' >> beam.GroupByKey()
-                                        | 'CountWords' >> self.CounterStater)
-        self.context = context
+        return self.run_ex(pipeline, context, driver_arguments['words_to_count'], driver_arguments['words_to_filter'])
+
+    def nope(self, pipeline, context):
         self.pipeline = pipeline
+        self.context = context
 
 
 @mock.patch('sys.argv', ["python"])  # Beam tries to parse cmdargs eagerly - it breaks external test launchers
@@ -71,7 +63,7 @@ class BeamJobTestCase(TestCase):
         # given
         state_mock.return_value = "DONE"
 
-        driver = CountWordsDriver(CounterStater(CounterState()))
+        driver = CountWordsDriver()
         job = BeamJob(
             id='count_words',
             entry_point=driver.run,
@@ -81,15 +73,50 @@ class BeamJobTestCase(TestCase):
             },
             test_pipeline=self._test_pipeline_with_label('count_words'))
 
-        count_words = Workflow(
-            workflow_id='count_words',
-            definition=[job])
-
         # when
-        count_words.run('2020-01-01')
+        job.execute(JobContext.make())
 
         # then executes the job with the arguments
-        self.assertEqual(driver.CounterStater.CounterState.counter, {'valid': 2, 'word': 1})
+        self.assertEqual(driver.counter, {'valid': 2, 'word': 1})
+
+        # and passes the context
+        self.assertIsNotNone(driver.context)
+        self.assertTrue(isinstance(driver.context, JobContext))
+
+        # and labels the job
+        self.assertEqual(
+            driver.pipeline._options.get_all_options()['labels'],
+            ['workflow_id=count_words'])
+
+        # and sets default value for execution_timeout_sec
+        self.assertEqual(job.execution_timeout_sec, DEFAULT_EXECUTION_TIMEOUT_IN_SECONDS)
+
+    @patch.object(RunnerResult, 'state', new_callable=mock.PropertyMock)
+    def test_should_run_new_entry_point(
+        self,
+        state_mock,
+        locate_project_mock,
+    ):
+        # given
+        state_mock.return_value = "DONE"
+
+        driver = CountWordsDriver()
+        job = BeamJob(
+            id='count_words',
+            entry_point=driver.run_ex,
+            entry_point_args=(
+                ['trash', 'valid', 'word', 'valid'],
+            ),
+            entry_point_kwargs={
+                'words_to_filter': ['valid', 'word'],
+            },
+            test_pipeline=self._test_pipeline_with_label('count_words'))
+
+        # when
+        job.execute(JobContext.make())
+
+        # then executes the job with the arguments
+        self.assertEqual(driver.counter, {'valid': 2, 'word': 1})
 
         # and passes the context
         self.assertIsNotNone(driver.context)
@@ -117,25 +144,17 @@ class BeamJobTestCase(TestCase):
         wait_until_finish_mock.return_value = 'DONE'
         state_mock.return_value = 'RUNNING'
 
-        driver = CountWordsDriver(CounterStater(CounterState()))
+        driver = CountWordsDriver()
+
         job = BeamJob(
             id='count_words',
-            entry_point=driver.run,
-            entry_point_arguments={
-                'words_to_filter': ['valid', 'word'],
-                'words_to_count': ['trash', 'valid', 'word', 'valid']
-            },
+            entry_point=driver.nope,
             test_pipeline=self._test_pipeline_with_label('count_words'),
             execution_timeout_sec=600)
 
-        count_words = Workflow(
-            workflow_id='count_words',
-            definition=[job])
-
         # then
         with self.assertRaises(RuntimeError) as e:
-            # when
-            count_words.run('2020-01-01')
+            job.execute(JobContext.make())
 
         # then
         self.assertEqual(cancel_mock.call_count, 1)
@@ -155,23 +174,15 @@ class BeamJobTestCase(TestCase):
         wait_until_finish_mock.return_value = 'DONE'
         state_mock.return_value = 'DONE'
 
-        driver = CountWordsDriver(CounterStater(CounterState()))
+        driver = CountWordsDriver()
         job = BeamJob(
             id='count_words',
-            entry_point=driver.run,
-            entry_point_arguments={
-                'words_to_filter': ['valid', 'word'],
-                'words_to_count': ['trash', 'valid', 'word', 'valid']
-            },
+            entry_point=driver.nope,
             test_pipeline=self._test_pipeline_with_label('count_words'),
             execution_timeout_sec=600)
 
-        count_words = Workflow(
-            workflow_id='count_words',
-            definition=[job])
-
         # when
-        count_words.run('2020-01-01')
+        job.execute(JobContext.make())
 
         # then
         self.assertEqual(cancel_mock.call_count, 0)
@@ -183,14 +194,10 @@ class BeamJobTestCase(TestCase):
     ):
         # given
         with self.assertRaises(ValueError):
-            driver = CountWordsDriver(CounterStater(CounterState()))
+            driver = CountWordsDriver()
             job = BeamJob(
                 id='count_words',
-                entry_point=driver.run,
-                entry_point_arguments={
-                    'words_to_filter': ['valid', 'word'],
-                    'words_to_count': ['trash', 'valid', 'word', 'valid']
-                },
+                entry_point=driver.nope,
                 test_pipeline=self._test_pipeline_with_label('count_words'),
                 execution_timeout_sec=1,
                 wait_until_finish=False)
@@ -204,25 +211,17 @@ class BeamJobTestCase(TestCase):
         # given
         _create_pipeline_mock.return_value.run.return_value = RunnerResult('DONE', None)
 
-        driver = CountWordsDriver(CounterStater(CounterState()))
+        driver = CountWordsDriver()
         options = PipelineOptions()
         job = BeamJob(
             id='count_words',
-            entry_point=driver.run,
-            entry_point_arguments={
-                'words_to_filter': ['valid', 'word'],
-                'words_to_count': ['trash', 'valid', 'word', 'valid']
-            },
+            entry_point=driver.nope,
             pipeline_options=options,
             execution_timeout_sec=10,
         )
 
-        count_words = Workflow(
-            workflow_id='count_words',
-            definition=[job])
-
         # when
-        count_words.run('2020-01-01')
+        job.execute(JobContext.make())
 
         # then
         options.get_all_options()
@@ -236,14 +235,10 @@ class BeamJobTestCase(TestCase):
         locate_project_mock,
     ):
         with self.assertRaises(ValueError):
-            driver = CountWordsDriver(CounterStater(CounterState()))
+            driver = CountWordsDriver()
             BeamJob(
                 id='count_words',
-                entry_point=driver.run,
-                entry_point_arguments={
-                    'words_to_filter': ['valid', 'word'],
-                    'words_to_count': ['trash', 'valid', 'word', 'valid']
-                },
+                entry_point=driver.nope,
                 execution_timeout_sec=1)
 
     def test_should_throw_if_pipeline_options_and_pipeline_both_provided(
@@ -251,14 +246,10 @@ class BeamJobTestCase(TestCase):
         locate_project_mock,
     ):
         with self.assertRaises(ValueError):
-            driver = CountWordsDriver(CounterStater(CounterState()))
+            driver = CountWordsDriver()
             BeamJob(
                 id='count_words',
-                entry_point=driver.run,
-                entry_point_arguments={
-                    'words_to_filter': ['valid', 'word'],
-                    'words_to_count': ['trash', 'valid', 'word', 'valid']
-                },
+                entry_point=driver.nope,
                 test_pipeline=self._test_pipeline_with_label('count_words'),
                 execution_timeout_sec=1,
                 pipeline_options=PipelineOptions())
@@ -269,3 +260,68 @@ class BeamJobTestCase(TestCase):
         google_cloud_options.labels = []
         google_cloud_options.labels.append(f'workflow_id={workflow_id}')
         return TestPipeline(options=google_cloud_options)
+
+    @patch('bigflow.dataflow.Pipeline')
+    def test_create_pipeline_dict_options(
+        self,
+        _create_pipeline_mock: mock.Mock,
+        locate_project_mock,
+    ):
+        # given
+        _create_pipeline_mock.return_value.run.return_value = RunnerResult('DONE', None)
+
+        driver = CountWordsDriver()
+        options = {
+            'job_name': "custom-my-job",
+            'labels': ["lable1", "label2"],
+            'streaming': True,
+            'project': "my-gcp-project",
+            'machine_type': "n2-standard-16",
+        }
+
+        job = BeamJob(
+            id='count_words',
+            entry_point=driver.nope,
+            pipeline_options=options,
+            execution_timeout_sec=10,
+        )
+
+        # when
+        job.execute(JobContext.make())
+
+        # then
+        options2 = _create_pipeline_mock.call_args[1]['options'].get_all_options(drop_default=True)
+
+        self.assertTrue(options2.pop('setup_file'))
+        self.assertDictEqual(options, options2)
+
+    @mock.patch('bigflow.dataflow.Pipeline')
+    @mock.patch('bigflow.build.reflect.get_project_spec')
+    def test_add_docker_to_pipelineoptions(
+        self,
+        get_project_spec_mock: mock.Mock,
+        _create_pipeline_mock: mock.Mock,
+        locate_project_mock,
+    ):
+        # given
+        _create_pipeline_mock.return_value.run.return_value = RunnerResult('DONE', None)
+        get_project_spec_mock.return_value.version = "1.2.3"
+        get_project_spec_mock.return_value.docker_repository = "my_repo"
+
+        driver = CountWordsDriver()
+        job = BeamJob(
+            id='count_words',
+            entry_point=driver.nope,
+            pipeline_options={},
+            use_docker_image=True,
+        )
+
+        # when
+        job.execute(JobContext.make())
+
+        # then
+        options2 = _create_pipeline_mock.call_args[1]['options'].get_all_options(drop_default=True)
+
+        self.assertIn('job_name', options2)
+        self.assertEqual('my_repo:1.2.3', options2['worker_harness_container_image'])
+        self.assertIn('use_runner_v2', options2['experiments'])


### PR DESCRIPTION
Changes in `bigflow.dataflow` module:
 - BeamJob accepts 'dict' as 'pipeline_options' parameter
 - BeamJob automatically puts 'job_name' and 'setup_file' parameters (when they are not present in 'pipeline_options')
 - New parameter 'use_docker_image'. When it is a string - it is used as 'worker_harness_container_image` pipeline option. If it is a `True` - bigflow use the same docker image name as '.dags/' and 'bigflow deploy'.
 - Minor refactorign - easier to overload some parts in sublcasses (if user needs some specific tuning).
 - 'entry_point' might take any number of args/kwargs (same style as 'threading.Thread')

Missing features: 
 - No documentation updates (as it is an experimental feature).
 - Prechecking that image name is valid (or/and deployed).
 