### PR TITLE
Improve project name/path inferring

### DIFF
--- a/bigflow/build/spec.py
+++ b/bigflow/build/spec.py
@@ -88,10 +88,10 @@ def parse_project_spec(
     logger.info("Prepare bigflow project spec...")
     name = name.replace("_", "-")  # PEP8 compliant package names
 
-    docker_repository = docker_repository or get_docker_repository_from_deployment_config(deployment_config_file)
+    docker_repository = docker_repository or get_docker_repository_from_deployment_config(project_dir / deployment_config_file)
     version = version or secure_get_version()
     packages = packages if packages is not None else discover_project_packages(project_dir)
-    requries = requries if requries is not None else read_project_requirements(project_requirements_file)
+    requries = requries if requries is not None else read_project_requirements(project_dir / project_requirements_file)
     metainfo = {k: kwargs.pop(k) for k in _PROJECT_METAINFO_KEYS if k in kwargs}
 
     setuptools = kwargs  # all unknown arguments
@@ -197,12 +197,12 @@ def read_project_spec(dir: Path) -> BigflowProjectSpec:
 
     try:
         return read_project_spec_nosetuppy(dir, **setuppy_kwargs)
-    except Exception:
+    except Exception as e:
         raise ValueError(
             "The project configuration is invalid. "
             "Check the documentation how to create a valid `setup.py`: "
             "https://github.com/allegro/bigflow/blob/master/docs/build.md"
-        )
+        ) from e
 
 
 # Provide defaults for project-spec
@@ -237,8 +237,8 @@ def get_docker_repository_from_deployment_config(deployment_config_file: Path) -
     import bigflow.cli   # TODO: refactor, remove this import
     try:
         config = bigflow.cli.import_deployment_config(str(deployment_config_file), 'docker_repository')
-    except ValueError:
-        raise ValueError(f"Can't find the specified deployment configuration: {deployment_config_file}")
+    except ValueError as e:
+        raise ValueError(f"Can't find the specified deployment configuration: {deployment_config_file}") from e
 
     if isinstance(config, bigflow.Config):
         config = config.resolve()

--- a/test/buildd/bf-projects/bf_selfbuild_project/bf_selfbuild_module.py
+++ b/test/buildd/bf-projects/bf_selfbuild_project/bf_selfbuild_module.py
@@ -1,4 +1,4 @@
 import bigflow.build.reflect as r
 
-def get_project_spec():
+def project_spec():
     return r.get_project_spec()

--- a/test/buildd/bf-projects/bf_selfbuild_project/scripts/subdir/infer_project_name.py
+++ b/test/buildd/bf-projects/bf_selfbuild_project/scripts/subdir/infer_project_name.py
@@ -1,0 +1,5 @@
+import bigflow.build.reflect
+
+spec = bigflow.build.reflect.get_project_spec()
+if spec.name != 'bf-selfbuild-project':
+    raise AssertionError(spec.name)

--- a/test/buildd/bf-projects/bf_selfbuild_project/test/test_example.py
+++ b/test/buildd/bf-projects/bf_selfbuild_project/test/test_example.py
@@ -1,6 +1,0 @@
-from unittest import TestCase
-
-
-class ExampleTestCase(TestCase):
-    def test_should_pass(self):
-        self.assertTrue(True)

--- a/test/buildd/bf-projects/bf_selfbuild_project/test/test_readspec.py
+++ b/test/buildd/bf-projects/bf_selfbuild_project/test/test_readspec.py
@@ -1,0 +1,12 @@
+import unittest
+import bigflow.build.reflect
+
+
+class ReadProjectSpecTestCase(unittest.TestCase):
+    def test_should_pass(self):
+        spec = bigflow.build.reflect.get_project_spec()
+        self.assertEqual(spec.name, "bf-selfbuild-project")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/buildd/test_reflect.py
+++ b/test/buildd/test_reflect.py
@@ -5,8 +5,6 @@ import pickle
 
 from test import mixins
 
-import bigflow.build.reflect
-
 
 class SelfBuildOldProjectTestCase(
     mixins.SubprocessMixin,
@@ -44,6 +42,7 @@ class _BaseBuildReflectTest(
         # then - check reading of project spec
         self.assertEqual("bf-selfbuild-project", self.runpy_n_dump('bf_selfbuild_project.buildme.project_spec').name)
         self.assertEqual("bf-selfbuild-project", self.runpy_n_dump('bf_selfbuild_other_package.buildme.project_spec').name)
+        #self.assertEqual("bf-selfbuild-project", self.runpy_n_dump('bf_selfbuild_module.project_spec').name)
 
         # then - self-build sdist/wheel/egg pacakges
         sdist_pkg = self.runpy_n_dump('bf_selfbuild_project.buildme.build_sdist')
@@ -96,3 +95,9 @@ class SelfBuildProjectFromSourcesTestCase(
     def test_reflected_build_from_sources(self):
         # then
         self.check_build_reflect()
+
+        # and - test pass (check if spec is available from tests)
+        self.subprocess_run(["python", "test/test_readspec.py"])
+
+        # and - project spec is available from scripts
+        self.subprocess_run(["python", "scripts/subdir/infer_project_name.py"])


### PR DESCRIPTION
This PR relaxates check for detecting project root. Now it don't try to read/parse pyproject.toml / setup.py
Also it scans all parent folders (allowing to infer project name from any .py script inside project dir).