### PR TITLE
Allow google-auth < 3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,8 @@
 google-cloud-storage>=1.30,<2
-google-auth>=1.20,<2
-
+# Maintainers, please do not require google-api-core>=2.x.x
+# Until this issue is closed
+# https://github.com/googleapis/google-cloud-python/issues/10566
+google-auth>=1.20,<3
 unittest-xml-reporting>=3.0.2,<4
 jinja2>=2.10,<3
 pip-tools>=5.3,<7


### PR DESCRIPTION
`google-auth` recently published a 2.0.0 release which removed support for Python 2.7. `google-auth` now requires Python >=3.6. No other breaking changes were made. You can see the full list of changes [here](https://github.com/googleapis/google-auth-library-python/commit/560cf1ed02a900436c5d9e0a0fb3f94b5fd98c55).

I am opening PRs to expand google-auth version ranges for packages that meet either of the following criteria:
* Package has >10,000 monthly downloads as of June 2021
* Package is owned by a Google team

`google-auth` is a dependency of many different libraries that interact with Google APIs. Increasing the time and number of packages with compatible pins on `google-auth` lowers the chance end developers who use multiple libraries will see dependency conflicts. 

If possible, please do not require `google-auth>=2.0.0` until https://github.com/googleapis/google-cloud-python/issues/10566 is resolved, as that will further reduce the likelihood of diamond dependency conflicts.

Googlers, see [this doc](https://docs.google.com/document/d/1euAvUsia_4zf98lNvpwA3K0o2b4y5Xr9xAkyzCnIMzQ/edit) for more information.
