### PR TITLE
FST-250 bf build arguments validation

### DIFF
--- a/bigflow/cli.py
+++ b/bigflow/cli.py
@@ -303,21 +303,6 @@ def _create_build_package_parser(subparsers):
     subparsers.add_parser('build-package', description='Builds .whl package from local sources.')
 
 
-def _valid_datetime(dt):
-    if dt == 'NOW':
-        return
-
-    try:
-        datetime.strptime(dt, "%Y-%m-%d %H:%M:%S")
-        return dt
-    except ValueError:
-        try:
-            datetime.strptime(dt, "%Y-%m-%d")
-            return dt
-        except ValueError:
-            raise ValueError("Not a valid date: '{0}'.".format(dt))
-
-
 def _add_build_dags_parser_arguments(parser):
     parser.add_argument('-w', '--workflow',
                         type=str,
@@ -330,7 +315,7 @@ def _add_build_dags_parser_arguments(parser):
                              'For workflows triggered hourly -- datetime in format: Y-m-d H:M:S, for example 2020-01-01 00:00:00. '
                              'For workflows triggered daily -- date in format: Y-m-d, for example 2020-01-01. '
                              'If empty or set as NOW, current hour is used.',
-                        type=_valid_datetime)
+                        type=bf_commons.valid_datetime)
 
 
 def _create_build_dags_parser(subparsers):

--- a/bigflow/commons.py
+++ b/bigflow/commons.py
@@ -320,3 +320,24 @@ def as_timedelta(v: None | str | Number | timedelta) -> timedelta | None:
         return None
     else:
         return timedelta(seconds=float(v))
+
+
+def valid_datetime(dt: str) -> str:
+    """
+    Validates provided datetime string. Raises ValueError for strings that are none of:
+    * 'NOW'
+    * valid '%Y-%m-%d %H:%M:%S'
+    * valid '%Y-%m-%d'
+    """
+    if dt == 'NOW':
+        return dt
+
+    try:
+        datetime.strptime(dt, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        try:
+            datetime.strptime(dt, "%Y-%m-%d")
+        except ValueError:
+            raise ValueError("Not a valid date: '{0}'.".format(dt))
+
+    return dt

--- a/test/bf-projects/bf_simple_pytest/bf_simple_pytest/workflow.py
+++ b/test/bf-projects/bf_simple_pytest/bf_simple_pytest/workflow.py
@@ -1,0 +1,6 @@
+import bigflow
+
+the_workflow = bigflow.Workflow(
+    workflow_id='the_workflow',
+    definition=[]
+)

--- a/test/test_commons.py
+++ b/test/test_commons.py
@@ -43,6 +43,45 @@ class CliTestCase(TestCase):
             # when
             decode_version_number_from_file_name(Path('/Users/image-0.1122123.0.tar'))
 
+    def test_valid_datetime_should_pass_for_NOW(self):
+        # when
+        valid_datetime('NOW')
+
+        # then
+        # no error is raised
+
+    def test_valid_datetime_should_pass_for_valid_YmdHMS(self):
+        # when
+        valid_datetime('2022-01-01 12:34:56')
+
+        # then
+        # no error is raised
+
+    def test_valid_datetime_should_raise_error_for_invalid_YmdHMS(self):
+        # then
+        with self.assertRaises(ValueError):
+            # when
+            valid_datetime('2022-01-01 34:56:78')
+
+    def test_valid_datetime_should_pass_for_valid_Ymd(self):
+        # when
+        valid_datetime('2022-01-01')
+
+        # then
+        # no error is raised
+
+    def test_valid_datetime_should_raise_error_for_invalid_Ymd(self):
+        # then
+        with self.assertRaises(ValueError):
+            # when
+            valid_datetime('2022-23-45')
+
+    def test_valid_datetime_should_raise_error_for_other_string(self):
+        # then
+        with self.assertRaises(ValueError):
+            # when
+            valid_datetime('foo bar baz')
+
     def _touch_file(self, file_name: str, content: str = ''):
         workdir = Path(os.getcwd())
         f = workdir / file_name


### PR DESCRIPTION
* moved `_valid_datetime` to `bigflow.commons` as `valid_datetime`
* shuffled activities order in `bf build` (was: package -> image -> dags, is: dags -> package -> image)
* moved workflow loading in `operate.build_dags` before other activities
* made `build`/`build-dags` commands fail when no workflows found for `ALL`/none workflow ID