### PR TITLE
Added .bigflow_env to .gitignore and fixed wrong doc URL in bigflow.build.spec error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.bigflow_env/
 
 # Spyder project settings
 .spyderproject

--- a/bigflow/build/spec.py
+++ b/bigflow/build/spec.py
@@ -217,7 +217,7 @@ def read_project_spec(dir: Path) -> BigflowProjectSpec:
         raise ValueError(
             "The project configuration is invalid. "
             "Check the documentation how to create a valid `setup.py`: "
-            "https://github.com/allegro/bigflow/blob/master/docs/build.md"
+            "https://github.com/allegro/bigflow/blob/master/docs/project_structure_and_build.md"
         ) from e
 
 


### PR DESCRIPTION
Added venv from readme to .gitignore, as some projects have it: https://github.com/search?q=bigflow_env+filename%3A.gitignore&type=code