### PR TITLE
update upload artifact action v2->v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Upload test report
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test-report
         path: build/test-report.html


### PR DESCRIPTION
As for now v2 is deprecated and v3 will be in a moment: https://github.com/actions/upload-artifact